### PR TITLE
Refactor auth session retrieval

### DIFF
--- a/src/components/useAuth.js
+++ b/src/components/useAuth.js
@@ -14,22 +14,25 @@ export const AuthProvider = ({ children }) => {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    console.log('Checking session');
-    const session = supabase.auth.session();
-    console.log('Session:', session);
+    const getSession = async () => {
+      setLoading(true);
+      console.log('Checking session');
+      const { data: { session } } = await supabase.auth.getSession();
+      console.log('Session:', session);
 
-    setUser(session?.user ?? null);
-    setLoading(false);
+      setUser(session?.user ?? null);
+      setLoading(false);
+    };
 
-    const { data: authListener } = supabase.auth.onAuthStateChange((event, session) => {
+    getSession();
+
+    const { data: { subscription } } = supabase.auth.onAuthStateChange((event, session) => {
       console.log('Auth state change:', event, session);
       setUser(session?.user ?? null);
       setLoading(false);
     });
 
-    return () => {
-      authListener.unsubscribe();
-    };
+    return () => subscription.unsubscribe();
   }, []);
 
   return (


### PR DESCRIPTION
## Summary
- fetch session asynchronously with `supabase.auth.getSession`
- update auth listener to use subscription and clean up
- manage loading state around async calls

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af37b41d8c832e84f1ab974bd1b787