### PR TITLE
Integrate admin page with global navigation

### DIFF
--- a/src/app/Admin/adminPage.module.css
+++ b/src/app/Admin/adminPage.module.css
@@ -1,93 +1,62 @@
 /* General container for the Admin page */
-.adminContainer {
+.userContainer {
   display: flex;
   flex-direction: column;
-  min-height: 100vh;
-  align-items: center;
-  justify-content: flex-start;
-  padding: 20px;
+  height: 100%;
+  width: 100%;
+  padding: 0;
   background-color: #f0f0f0;
   color: #333;
 }
-/* Navbar styling */
-.navbar {
+
+/* Main content area */
+.userContent {
   width: 100%;
+  flex-grow: 1;
   display: flex;
-  justify-content: space-between; /* Spacing between the title and button */
+  flex-direction: column;
   align-items: center;
-  padding: 20px;
-  background-color: #2a9d8f; /* Same as before for consistency */
-  color: white;
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1); /* Subtle shadow for navbar */
+  padding: 10px;
 }
 
-.navbarTitle {
-  font-size: 2rem;
-  font-weight: bold;
+/* Footer styling */
+.userFooter {
+  width: 100%;
+  padding: 5px;
+  text-align: center;
+  background-color: #264653;
+  color: #fff;
+  flex-shrink: 0;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.userFooter p {
   margin: 0;
+  font-size: 1rem;
 }
 
-/* Updated Sign Out button styling */
-/* trying to trigger automated build */
-
+/* Sign Out button styling */
 .signOutButton {
-  background-color: #ff6b6b;
+  background-color: #c1121f;
   color: white;
-  padding: 12px 24px;
-  border: none;
+  padding: 8px 16px;
+  font-size: 1.1rem;
   border-radius: 8px;
   cursor: pointer;
-  font-size: 1rem;
   transition: background-color 0.3s ease, box-shadow 0.3s ease;
   box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
 }
 
 .signOutButton:hover {
-  background-color: #d64545;
+  background-color: #a11a1a;
   box-shadow: 0 6px 10px rgba(0, 0, 0, 0.15);
 }
 
 .signOutButton:active {
-  background-color: #bf3333;
+  background-color: #8b0000;
   box-shadow: none;
-}
-/* Header styling */
-.adminHeader {
-  width: 100%;
-  padding: 20px;
-  text-align: center;
-  background-color: #2a9d8f;
-  color: white;
-}
-
-.adminHeader h1 {
-  margin: 0;
-  font-size: 2.5rem;
-  font-weight: bold;
-}
-
-/* Main content area */
-.adminContent {
-  width: 100%;
-  max-width: 1200px;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  padding: 20px;
-}
-
-/* Footer styling */
-.adminFooter {
-  width: 100%;
-  padding: 10px;
-  text-align: center;
-  background-color: #2a9d8f;
-  color: white;
-  margin-top: auto;
-}
-
-.adminFooter p {
-  margin: 0;
 }
 
 /* Button styling */

--- a/src/app/Admin/page.tsx
+++ b/src/app/Admin/page.tsx
@@ -6,6 +6,7 @@ import Modal from '@/components/Modal/Modal';
 import Sidebar from '@/components/Sidebar/Sidebar';
 import CurrentSeasonModal from '@/components/CurrentSeason/CurrentSeasonModal';
 import NextSeasonModal from '@/components/NextSeason/NextSeason';
+import Header from '@/components/Header';
 import { supabase } from '@/supabaseClient'; // Import the Supabase client
 import { User } from '@supabase/supabase-js';
 
@@ -240,17 +241,11 @@ const AdminPage = () => {
   }
 
   return (
-    <div className={styles.adminContainer}>
-      {/* Header */}
-      <header className={styles.navbar}>
-        <h1 className={styles.navbarTitle}>Admin Dashboard</h1>
-        <button className={styles.signOutButton} onClick={handleSignOut}>
-          Sign Out
-        </button>
-      </header>
+    <div className={styles.userContainer}>
+      <Header />
 
       {/* Main Content */}
-      <main className={styles.adminContent}>
+      <main className={styles.userContent}>
         <div className={styles.container}>
           <h2>{seasonName} Standings</h2>
           <div className={styles.secondaryScreenOptions}>
@@ -322,8 +317,11 @@ const AdminPage = () => {
       </main>
 
       {/* Footer */}
-      <footer className={styles.adminFooter}>
+      <footer className={styles.userFooter}>
         <p>&copy; 2025 Buckets Game. Admin Panel. All rights reserved.</p>
+        <button className={styles.signOutButton} onClick={handleSignOut}>
+          Sign Out
+        </button>
       </footer>
     </div>
   );


### PR DESCRIPTION
## Summary
- Replace standalone admin header with shared `<Header>` component for consistent navigation
- Align admin dashboard structure and styling with rest of app, including shared footer and sign-out button

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af38e89c0c832e968cfc2e8ac5b940