### PR TITLE
Enhance stats page with table layout and live updates

### DIFF
--- a/src/app/Stats/Stats.module.css
+++ b/src/app/Stats/Stats.module.css
@@ -1,18 +1,27 @@
   .statsContainer {
     padding: 20px;
   }
-  
-  .statsList {
-    display: flex;
-    flex-wrap: wrap;
-    gap: 20px;
+
+  .tableWrapper {
+    width: 100%;
+    overflow-x: auto;
   }
-  
-  .playerStat {
+
+  .statsTable {
+    width: 100%;
+    border-collapse: collapse;
+  }
+
+  .statsTable th,
+  .statsTable td {
     border: 1px solid #ccc;
-    padding: 15px;
-    width: 250px;
-    background-color: #f9f9f9;
+    padding: 8px;
+    text-align: center;
+  }
+
+  .statsTable th {
+    background-color: #264653;
+    color: #fff;
   }
   
   .navbarTitle {


### PR DESCRIPTION
## Summary
- Rework player stats page into a table with totals, averages, and shot percentage
- Subscribe to Supabase changes so stats update in real time
- Style table for clearer presentation

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af3b31ab88832e891d26ac87e77cc2