### PR TITLE
Add PPS stat to standings

### DIFF
--- a/src/app/Standings/StandingsPage.module.css
+++ b/src/app/Standings/StandingsPage.module.css
@@ -70,7 +70,7 @@
 
 .row {
   display: grid;
-  grid-template-columns: 1fr 1fr 1fr; /* Two fractions for name, one each for shots and points */
+  grid-template-columns: 2fr 1fr 1fr 1fr; /* Name gets more space than stats */
   align-items: center; /* Ensure vertical alignment */
   padding: 12px 2px;
   font-size: 1.5rem;
@@ -83,14 +83,15 @@
   flex-basis: 33%;
 }
 .shotsLeft,
-.totalPoints {
-  flex-basis: 33%; /* Ensure each column gets 33% of the width */
+.totalPoints,
+.pps {
+  flex-basis: 25%; /* Ensure each column gets equal width */
   text-align: center;
 }
 
 /* Ensure that the columns are evenly spaced and aligned */
 .columnHeader {
-  flex-basis: 33%;
+  flex-basis: 25%;
   text-align: center;
   font-weight: bold;
 }

--- a/src/app/Standings/page.tsx
+++ b/src/app/Standings/page.tsx
@@ -27,6 +27,7 @@ interface TeamWithPlayers {
     name: string;
     shots_left: number;
     player_score: number;
+    pps: number;
   }[];
   total_shots: number;
   team_score: number;
@@ -246,17 +247,19 @@ const StandingsPage: React.FC = () => {
                 .eq('player_id', player.player_id)
                 .eq('season_id', activeSeasonId)
                 .single();
-  
+
               if (piError || !playerInstance) throw piError;
               // Calculate streaks
 
               const shotsMadeInRow = await calculateShotsMadeInRow(playerInstance.player_instance_id);
               const shotsMissedInRow = await calculateShotsMissedInRow(playerInstance.player_instance_id);
               console.log(shotsMadeInRow, shotsMissedInRow);
+              const shotsTaken = Math.max(0, activeSeason.shot_total - playerInstance.shots_left);
               return {
                 name: player.name,
                 shots_left: playerInstance.shots_left,
                 player_score: playerInstance.score,
+                pps: shotsTaken > 0 ? playerInstance.score / shotsTaken : 0,
                 tier_color: player.tiers?.color || '#000',
                 shots_made_in_row: shotsMadeInRow,
                 shots_missed_in_row: shotsMissedInRow,
@@ -488,6 +491,7 @@ const timeUntilMidnight = midnight.getTime() - now.getTime();
                   <span className={styles.columnHeader}>Name</span>
                   <span className={styles.columnHeader}>Shots Left</span>
                   <span className={styles.columnHeader}>Total Points</span>
+                  <span className={styles.columnHeader}>PPS</span>
                 </div>
                 {team.players.map((player, playerIndex) => (
                   <div key={playerIndex} className={styles.row}>
@@ -519,6 +523,7 @@ const timeUntilMidnight = midnight.getTime() - now.getTime();
                     {/* Player Stats */}
                     <span className={styles.shotsLeft}>{player.shots_left}</span>
                     <span className={styles.totalPoints}>{player.player_score}</span>
+                    <span className={styles.pps}>{player.pps.toFixed(2)}</span>
                   </div>
                 ))}
                 {/* Team Stats */}


### PR DESCRIPTION
## Summary
- compute points-per-shot for each player based on shots used in the active season
- display the PPS value alongside existing stats on the standings page and adjust layout

## Testing
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f697249dc832cac8bf4ff7025b84a)