### PR TITLE
Add waiver disclaimer for fourth daily shot

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -323,6 +323,14 @@ const Modal: React.FC<ModalProps> = ({ name, isOpen, onClose, playerId }) => {
           <p>
             Shots Taken Today: <span>{shotsTakenToday !== null ? shotsTakenToday : '...'}</span>
           </p>
+          {shotsTakenToday === 3 && (
+            <p className="waiver-disclaimer">
+              <strong>
+                You are logging your 4th shot, any additional shots today will be waiver attempts. For a waiver
+                attempt you get only one die to roll, no practice shot, and you sacrifice your second attempt.
+              </strong>
+            </p>
+          )}
           <div className="points">
             <button className={points === 0 ? 'selected' : ''} onClick={() => setPoints(0)}>0</button>
             <button className={points === 1 ? 'selected' : ''} onClick={() => setPoints(1)}>1</button>

--- a/src/components/Modal/modal.css
+++ b/src/components/Modal/modal.css
@@ -171,3 +171,10 @@ button.selected:hover {
 .actions button {
   margin: 10px;
 }
+
+.waiver-disclaimer {
+  margin: 12px 0;
+  color: #b00020;
+  font-weight: 700;
+  line-height: 1.5;
+}


### PR DESCRIPTION
## Summary
- show a waiver disclaimer when a player is logging their fourth shot of the day in the admin modal
- add styling for the new disclaimer message to highlight the warning

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f6fe3dff4832c9f99713c871914f3)