### PR TITLE
Ensure admin player list stays alphabetized

### DIFF
--- a/src/app/Admin/page.tsx
+++ b/src/app/Admin/page.tsx
@@ -20,9 +20,12 @@ interface TierWithPlayers {
   color: string;
   players: Player[];
 }
+
+const sortPlayersByName = (players: Player[] = []) =>
+  [...players].sort((a, b) => a.name.localeCompare(b.name));
 /**
  * AdminPage Component
- * 
+ *
  * This component serves as the admin dashboard for managing various aspects of the application.
  * It displays the current season's standings, allows the admin to view player details.
  */
@@ -101,7 +104,12 @@ const AdminPage = () => {
       if (tiersError) {
         console.error('Error fetching tiers:', tiersError);
       } else {
-        setTiers(tiersData || []); // Update state with fetched data
+        const sortedTiers = (tiersData || []).map((tier) => ({
+          ...tier,
+          players: sortPlayersByName(tier.players || []),
+        }));
+
+        setTiers(sortedTiers); // Update state with fetched data
       }
     };
 


### PR DESCRIPTION
## Summary
- sort fetched tier players by name so the admin list stays alphabetical
- keep alphabetical ordering intact as players are added through realtime updates

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f7372cfb0832cad45557f1c12690d)