### PR TITLE
Sort admin player list by last name

### DIFF
--- a/src/app/Admin/page.tsx
+++ b/src/app/Admin/page.tsx
@@ -21,8 +21,27 @@ interface TierWithPlayers {
   players: Player[];
 }
 
+const getSortableLastName = (name: string) => {
+  const trimmedName = name.trim();
+  const nameParts = trimmedName.split(/\s+/);
+
+  if (nameParts.length === 1) return trimmedName;
+
+  return nameParts[nameParts.length - 1];
+};
+
 const sortPlayersByName = (players: Player[] = []) =>
-  [...players].sort((a, b) => a.name.localeCompare(b.name));
+  [...players].sort((a, b) => {
+    const lastNameComparison = getSortableLastName(a.name).localeCompare(
+      getSortableLastName(b.name),
+      undefined,
+      { sensitivity: 'base' },
+    );
+
+    if (lastNameComparison !== 0) return lastNameComparison;
+
+    return a.name.localeCompare(b.name);
+  });
 /**
  * AdminPage Component
  *


### PR DESCRIPTION
## Summary
- update admin player sorting to prioritize last names while keeping names without initials in order

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f7c63c91c832c955798e23a3490f7)