### PR TITLE
Add Buckets Bracket link and info page

### DIFF
--- a/src/app/BucketsBracket/BucketsBracket.module.css
+++ b/src/app/BucketsBracket/BucketsBracket.module.css
@@ -1,0 +1,44 @@
+.page {
+  min-height: 100vh;
+  background: #f0f0f0;
+  color: #1f2933;
+}
+
+.content {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 24px 16px 48px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.title {
+  font-size: 2.5rem;
+  color: #264653;
+  margin: 0;
+}
+
+.card {
+  background: #ffffff;
+  border-radius: 10px;
+  padding: 18px 16px;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+  border: 1px solid #e3e8ee;
+}
+
+.card h2 {
+  margin-top: 0;
+  color: #1d3557;
+}
+
+.card p {
+  margin: 0 0 8px;
+}
+
+.card ul {
+  margin: 0;
+  padding-left: 20px;
+  display: grid;
+  gap: 8px;
+}

--- a/src/app/BucketsBracket/page.tsx
+++ b/src/app/BucketsBracket/page.tsx
@@ -1,0 +1,97 @@
+import Header from '@/components/Header';
+import styles from './BucketsBracket.module.css';
+
+const BucketsBracketPage = () => {
+  return (
+    <div className={styles.page}>
+      <Header />
+      <main className={styles.content}>
+        <h1 className={styles.title}>Buckets Bracket</h1>
+
+        <section className={styles.card}>
+          <h2>Project Overview</h2>
+          <p>
+            Build a web app that creates and manages single-elimination tournament brackets similar to BracketHQ, including setup and live phases, auto sizing with byes, and live previews during setup.
+          </p>
+        </section>
+
+        <section className={styles.card}>
+          <h2>Goal</h2>
+          <p>
+            Provide single-elimination bracket creation with player setup, seeding support, automatic bracket sizing with byes, and real-time updates while matches are scored and advanced.
+          </p>
+        </section>
+
+        <section className={styles.card}>
+          <h2>Core Requirements</h2>
+          <ul>
+            <li>Single elimination brackets for 2 to 128+ players.</li>
+            <li>Bracket sizing picks the next power of two and fills remaining slots with BYE entries that automatically advance opponents.</li>
+            <li>Setup phase lets organizers create tournaments, add players with optional metadata, seed any subset of players, and randomize unseeded slots.</li>
+            <li>Live preview updates instantly, showing seeds and placements and preventing invalid seeds.</li>
+            <li>Transition from draft to live locks player lists by default.</li>
+            <li>Live phase supports score entry, automatic advancement, validation against ties, and rollback when scores are cleared.</li>
+            <li>Viewer experience updates in real time via shareable links.</li>
+            <li>Persistent navigation button linking back to another page on the domain.</li>
+          </ul>
+        </section>
+
+        <section className={styles.card}>
+          <h2>Bracket Generation Rules</h2>
+          <ul>
+            <li>Determine bracket size, generate matches for all rounds, and wire winners to subsequent rounds.</li>
+            <li>Place seeded players into standard seed positions; distribute unseeded players randomly into remaining slots.</li>
+            <li>Fill leftover slots with BYE entries and auto-advance players paired against BYEs.</li>
+            <li>Ensure placement keeps top seeds separated following traditional single-elimination pairing.</li>
+          </ul>
+        </section>
+
+        <section className={styles.card}>
+          <h2>Live Phase + Viewer Experience</h2>
+          <ul>
+            <li>Organizer score entry sets winners based on higher scores and advances them immediately.</li>
+            <li>Ties are invalid and should surface an error.</li>
+            <li>Clearing a score rolls back downstream advancements.</li>
+            <li>Public tournament pages reflect live updates through WebSockets or SSE.</li>
+          </ul>
+        </section>
+
+        <section className={styles.card}>
+          <h2>Data Model</h2>
+          <p>The model includes Tournament, Player, Match, and handling for BYE slots.</p>
+          <ul>
+            <li>Tournament: id, name, status (DRAFT/LIVE/COMPLETED), timestamps.</li>
+            <li>Player: id, tournamentId, name, seed (nullable), metadata such as team or notes.</li>
+            <li>Match: roundNumber, matchNumber, slot players, scores, winner tracking, and pointers to the next match/slot.</li>
+            <li>BYE handling uses null player slots and auto-advancement when a player faces a BYE.</li>
+          </ul>
+        </section>
+
+        <section className={styles.card}>
+          <h2>Routes</h2>
+          <ul>
+            <li>/tournaments/new – create tournament and preview bracket.</li>
+            <li>/tournaments/:id/setup – edit draft tournaments.</li>
+            <li>/tournaments/:id/live – organizer scoring UI.</li>
+            <li>/tournaments/:id – public viewer bracket page.</li>
+          </ul>
+        </section>
+
+        <section className={styles.card}>
+          <h2>Acceptance Criteria</h2>
+          <ul>
+            <li>Create tournaments with any player count, seeding only some, and randomizing the rest.</li>
+            <li>Bracket preview updates instantly and displays names plus seeds.</li>
+            <li>Bracket sizing adds BYEs correctly and advances players paired with BYEs.</li>
+            <li>Starting the tournament locks setup and enables live scoring.</li>
+            <li>Score entry advances winners automatically; clearing scores rolls back progression.</li>
+            <li>Viewer pages update live without refresh.</li>
+            <li>Header includes a clear link back to another page on the site.</li>
+          </ul>
+        </section>
+      </main>
+    </div>
+  );
+};
+
+export default BucketsBracketPage;

--- a/src/app/Standings/StandingsPage.module.css
+++ b/src/app/Standings/StandingsPage.module.css
@@ -113,6 +113,28 @@
   box-sizing: border-box;
 }
 
+.bracketLinkRow {
+  width: 100%;
+  display: flex;
+  justify-content: flex-end;
+  margin-bottom: 10px;
+}
+
+.bracketLink {
+  background-color: #264653;
+  color: #ffffff;
+  padding: 10px 16px;
+  border-radius: 10px;
+  font-weight: 700;
+  text-decoration: none;
+  transition: background-color 0.3s ease, transform 0.2s ease;
+}
+
+.bracketLink:hover {
+  background-color: #1d3557;
+  transform: translateY(-1px);
+}
+
 .seasonTitle {
   font-size: 3rem;
   font-weight: bold;

--- a/src/app/Standings/page.tsx
+++ b/src/app/Standings/page.tsx
@@ -486,6 +486,9 @@ const timeUntilMidnight = midnight.getTime() - now.getTime();
     <main className={styles.userContent}>
         {/* Standings View*/}
         <div className={styles.container}>
+          <div className={styles.bracketLinkRow}>
+            <a className={styles.bracketLink} href="/BucketsBracket">Buckets Bracket</a>
+          </div>
           <h2 className={styles.seasonTitle}>{season.season_name} Standings</h2>
           <div className={styles.teams}>
             {teams.map((team, index) => (

--- a/src/components/Header.module.css
+++ b/src/components/Header.module.css
@@ -22,6 +22,18 @@
     cursor: pointer;
     padding: 0.5rem 1rem;
   }
+
+  .navTextLink {
+    border: 1px solid #ffffff;
+    border-radius: 8px;
+    font-weight: 600;
+    transition: background-color 0.3s ease, color 0.3s ease;
+  }
+
+  .navTextLink:hover {
+    background-color: #ffffff;
+    color: #264653;
+  }
   /* Navbar styling */
   .navbar {
     width: 100%;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -74,10 +74,10 @@ export default function Header() {
                     height="65"
                     onClick={() => handleNavigation('FreeAgency')}>
                 </Image>
-                <Image 
+                <Image
                     data-tooltip="Rules"
                     data-tooltip-loc="below"
-                    className={`${styles.navItem} ${pathname === '/Rules' ? styles.active : ''} invert`} 
+                    className={`${styles.navItem} ${pathname === '/Rules' ? styles.active : ''} invert`}
                     src={rulesLogo}
                     alt='Rules'
                     width="65"
@@ -94,10 +94,15 @@ export default function Header() {
                     height="65"
                     onClick={() => handleNavigation('Stats')}>
                 </Image>
-                {/* <Image 
+                <button
+                    className={`${styles.navItem} ${styles.navTextLink} ${pathname === '/BucketsBracket' ? styles.active : ''}`}
+                    onClick={() => handleNavigation('BucketsBracket')}>
+                    Buckets Bracket
+                </button>
+                {/* <Image
                     data-tooltip="User"
                     data-tooltip-loc="below"
-                    className={`${styles.navItem} ${pathname === '/User' ? styles.active : ''} invert`} 
+                    className={`${styles.navItem} ${pathname === '/User' ? styles.active : ''} invert`}
                     src={userLogo}
                     alt='Stats'
                     width="65"


### PR DESCRIPTION
## Summary
- add a Buckets Bracket nav button and header link from the Standings page
- create a Buckets Bracket page that summarizes the bracket project requirements and routes
- style the new navigation button and page content to match the existing layout

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f81a081f0832cbf986c1fd9b86852)