### PR TITLE
Sort tied players by PPS on standings

### DIFF
--- a/src/app/Standings/page.tsx
+++ b/src/app/Standings/page.tsx
@@ -270,8 +270,18 @@ const StandingsPage: React.FC = () => {
             })
           );
   
-          // Sort players by their score, descending
-          playersWithStats.sort((a, b) => b.player_score - a.player_score);
+          // Sort players by their score, descending. Break ties with PPS so higher efficiency ranks above.
+          playersWithStats.sort((a, b) => {
+            if (b.player_score !== a.player_score) {
+              return b.player_score - a.player_score;
+            }
+
+            if (b.pps !== a.pps) {
+              return b.pps - a.pps;
+            }
+
+            return a.name.localeCompare(b.name);
+          });
           // Calculate total shots left for the team
 
           const totalShots = playersWithStats.reduce((acc, player) => acc + player.shots_left, 0);


### PR DESCRIPTION
## Summary
- add PPS-based tie-breaker when sorting players with equal scores on the standings page
- maintain deterministic ordering by falling back to player name when PPS is also equal

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f83edf9ac832c928ba59566101ca3)