### PR TITLE
Add live single-elimination bracket builder

### DIFF
--- a/src/app/api/tournaments/[id]/events/route.ts
+++ b/src/app/api/tournaments/[id]/events/route.ts
@@ -1,0 +1,34 @@
+import { NextResponse } from 'next/server';
+import { getTournament, subscribe } from '@/lib/tournamentStore';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(_: Request, { params }: { params: { id: string } }) {
+  const tournament = getTournament(params.id);
+  if (!tournament) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+
+  const stream = new ReadableStream({
+    start(controller) {
+      const send = (payload: any) => {
+        controller.enqueue(`data: ${JSON.stringify(payload)}\n\n`);
+      };
+      send(tournament);
+      const unsubscribe = subscribe(params.id, send);
+      const interval = setInterval(() => send(getTournament(params.id)), 30000);
+      controller.enqueue(': connected\n\n');
+      return () => {
+        clearInterval(interval);
+        unsubscribe();
+      };
+    },
+  });
+
+  return new Response(stream, {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/event-stream',
+      Connection: 'keep-alive',
+      'Cache-Control': 'no-cache, no-transform',
+    },
+  });
+}

--- a/src/app/api/tournaments/[id]/randomize/route.ts
+++ b/src/app/api/tournaments/[id]/randomize/route.ts
@@ -1,0 +1,13 @@
+import { NextResponse } from 'next/server';
+import { shuffleUnseeded } from '@/lib/tournamentStore';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(_: Request, { params }: { params: { id: string } }) {
+  try {
+    const tournament = shuffleUnseeded(params.id);
+    return NextResponse.json(tournament);
+  } catch (error: any) {
+    return NextResponse.json({ error: error?.message ?? 'Unable to randomize' }, { status: 400 });
+  }
+}

--- a/src/app/api/tournaments/[id]/route.ts
+++ b/src/app/api/tournaments/[id]/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server';
+import { getTournament, updateTournamentSetup, startTournament } from '@/lib/tournamentStore';
+import { TournamentSeedData } from '@/lib/bracket';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET(_: Request, { params }: { params: { id: string } }) {
+  const tournament = getTournament(params.id);
+  if (!tournament) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  return NextResponse.json(tournament);
+}
+
+export async function PATCH(request: Request, { params }: { params: { id: string } }) {
+  const payload = (await request.json()) as TournamentSeedData & { status?: string };
+  const tournament = getTournament(params.id);
+  if (!tournament) return NextResponse.json({ error: 'Not found' }, { status: 404 });
+  if (payload.status === 'LIVE') {
+    const next = startTournament(params.id);
+    return NextResponse.json(next);
+  }
+  const updated = updateTournamentSetup(params.id, payload);
+  return NextResponse.json(updated);
+}

--- a/src/app/api/tournaments/[id]/score/route.ts
+++ b/src/app/api/tournaments/[id]/score/route.ts
@@ -1,0 +1,14 @@
+import { NextResponse } from 'next/server';
+import { submitScore } from '@/lib/tournamentStore';
+
+export const dynamic = 'force-dynamic';
+
+export async function POST(request: Request, { params }: { params: { id: string } }) {
+  const { matchId, scoreA, scoreB } = await request.json();
+  try {
+    const tournament = submitScore(params.id, matchId, scoreA ?? null, scoreB ?? null);
+    return NextResponse.json(tournament);
+  } catch (error: any) {
+    return NextResponse.json({ error: error?.message ?? 'Unable to submit' }, { status: 400 });
+  }
+}

--- a/src/app/api/tournaments/route.ts
+++ b/src/app/api/tournaments/route.ts
@@ -1,0 +1,23 @@
+import { NextResponse } from 'next/server';
+import { createTournament, listTournaments, seedDemo } from '@/lib/tournamentStore';
+import { TournamentSeedData } from '@/lib/bracket';
+
+export const dynamic = 'force-dynamic';
+
+seedDemo();
+
+export async function GET() {
+  return NextResponse.json(listTournaments());
+}
+
+export async function POST(request: Request) {
+  const payload = (await request.json()) as TournamentSeedData;
+  if (!payload.name) {
+    return NextResponse.json({ error: 'Name is required' }, { status: 400 });
+  }
+  if (!payload.players || payload.players.length < 2) {
+    return NextResponse.json({ error: 'At least two players required' }, { status: 400 });
+  }
+  const tournament = createTournament(payload);
+  return NextResponse.json(tournament, { status: 201 });
+}

--- a/src/app/bracket/page.tsx
+++ b/src/app/bracket/page.tsx
@@ -1,0 +1,21 @@
+import Link from 'next/link';
+
+export default function BracketLanding() {
+  return (
+    <div className="space-y-4">
+      <h1 className="text-3xl font-bold">Single-Elimination Bracket Builder</h1>
+      <p className="text-zinc-300 max-w-3xl">
+        Create, seed, and run single-elimination tournaments with automatic BYEs, live score entry, and a real-time viewer
+        experience. Start below or jump into an existing bracket.
+      </p>
+      <div className="flex gap-3">
+        <Link href="/tournaments/new" className="px-4 py-2 bg-blue-600 rounded text-white">
+          Create new tournament
+        </Link>
+        <Link href="/" className="px-4 py-2 border border-zinc-700 rounded text-white">
+          Go to home
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -34,19 +34,27 @@ export default function RootLayout({
 }: Readonly<{
   children: React.ReactNode; // The content to render inside the layout
 }>) {
+  const backToMain = process.env.NEXT_PUBLIC_MAIN_SITE_URL || '/';
   return (
     <html lang="en">
       {/* Include Google's GSI Client library for authentication */}
       <script src="https://accounts.google.com/gsi/client" async defer></script>
 
       <body className={inter.className}>
-
+        <header className="flex items-center justify-between px-6 py-3 border-b border-zinc-800 bg-black text-white">
+          <Link href="/bracket" className="font-semibold">
+            Bracket Builder
+          </Link>
+          <Link href={backToMain} className="text-sm text-blue-300 hover:text-blue-200">
+            Back to Main Site
+          </Link>
+        </header>
         {/**
          * Main Content Area:
          * - The `children` prop represents the content of the current page being rendered.
          * - It is wrapped with padding for consistent spacing.
          */}
-        <main className="p-4 h-screen">
+        <main className="p-4 h-[calc(100vh-64px)] bg-zinc-950 text-white">
           <TooltipProvider></TooltipProvider>
           {children}
         </main>

--- a/src/app/tournaments/[id]/live/page.tsx
+++ b/src/app/tournaments/[id]/live/page.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { useParams } from 'next/navigation';
+import Bracket from '@/components/Bracket';
+import useTournament from '@/hooks/useTournament';
+import { useState } from 'react';
+
+export default function LivePage() {
+  const params = useParams<{ id: string }>();
+  const { tournament, error } = useTournament(params.id);
+  const [message, setMessage] = useState<string | null>(null);
+
+  const handleScoreChange = async (matchId: string, scoreA: number | null, scoreB: number | null) => {
+    setMessage(null);
+    const res = await fetch(`/api/tournaments/${params.id}/score`, {
+      method: 'POST',
+      body: JSON.stringify({ matchId, scoreA, scoreB }),
+    });
+    if (!res.ok) {
+      const data = await res.json();
+      setMessage(data.error || 'Unable to submit score');
+    }
+  };
+
+  if (error) return <div className="text-red-400">{error}</div>;
+  if (!tournament) return <div>Loading...</div>;
+
+  return (
+    <div className="space-y-3">
+      <h1 className="text-2xl font-bold">Live scoring - {tournament.name}</h1>
+      <div className="text-sm text-zinc-400">Enter scores to advance winners automatically. Ties are not allowed.</div>
+      {message && <div className="text-red-400 text-sm">{message}</div>}
+      <Bracket tournament={tournament} editable onScoreChange={handleScoreChange} />
+    </div>
+  );
+}

--- a/src/app/tournaments/[id]/page.tsx
+++ b/src/app/tournaments/[id]/page.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import { useParams } from 'next/navigation';
+import Bracket from '@/components/Bracket';
+import useTournament from '@/hooks/useTournament';
+import Link from 'next/link';
+
+export default function TournamentViewer() {
+  const params = useParams<{ id: string }>();
+  const { tournament, error } = useTournament(params.id);
+
+  if (error) return <div className="text-red-400">{error}</div>;
+  if (!tournament) return <div>Loading...</div>;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">{tournament.name}</h1>
+          <p className="text-zinc-400 text-sm">Live updates stream to this page automatically.</p>
+        </div>
+        <Link href={`/tournaments/${params.id}/live`} className="px-3 py-1 bg-blue-600 rounded">
+          Organizer scoring
+        </Link>
+      </div>
+      <Bracket tournament={tournament} />
+    </div>
+  );
+}

--- a/src/app/tournaments/[id]/setup/page.tsx
+++ b/src/app/tournaments/[id]/setup/page.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import { useParams, useRouter } from 'next/navigation';
+import useTournament from '@/hooks/useTournament';
+import Bracket from '@/components/Bracket';
+
+export default function SetupPage() {
+  const params = useParams<{ id: string }>();
+  const router = useRouter();
+  const { tournament, error } = useTournament(params.id);
+
+  const handleRandomize = async () => {
+    await fetch(`/api/tournaments/${params.id}/randomize`, { method: 'POST' });
+  };
+
+  const handleStart = async () => {
+    await fetch(`/api/tournaments/${params.id}`, { method: 'PATCH', body: JSON.stringify({ status: 'LIVE' }) });
+    router.push(`/tournaments/${params.id}/live`);
+  };
+
+  if (error) return <div className="text-red-400">{error}</div>;
+  if (!tournament) return <div>Loading...</div>;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">{tournament.name}</h1>
+          <p className="text-zinc-400 text-sm">Seed players, randomize unseeded, and preview the bracket.</p>
+        </div>
+        <div className="flex gap-2">
+          <button className="px-3 py-1 bg-blue-600 rounded" onClick={handleRandomize} disabled={tournament.status !== 'DRAFT'}>
+            Randomize Unseeded
+          </button>
+          <button className="px-3 py-1 bg-green-600 rounded" onClick={handleStart} disabled={tournament.status !== 'DRAFT'}>
+            Start Tournament
+          </button>
+        </div>
+      </div>
+      <div className="text-sm text-zinc-400">Status: {tournament.status}</div>
+      <Bracket tournament={tournament} />
+    </div>
+  );
+}

--- a/src/app/tournaments/new/page.tsx
+++ b/src/app/tournaments/new/page.tsx
@@ -1,0 +1,108 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import Bracket from '@/components/Bracket';
+import PlayerEditor from '@/components/PlayerEditor';
+import { TournamentSeedData, buildTournament, randomizeUnseededPlayers } from '@/lib/bracket';
+
+export default function NewTournamentPage() {
+  const router = useRouter();
+  const [name, setName] = useState('My Tournament');
+  const [description, setDescription] = useState('');
+  const [visibility, setVisibility] = useState<'public' | 'private'>('public');
+  const [players, setPlayers] = useState(
+    Array.from({ length: 4 }).map((_, idx) => ({ id: crypto.randomUUID(), name: `Player ${idx + 1}`, seed: idx < 2 ? idx + 1 : null })),
+  );
+  const [error, setError] = useState<string | null>(null);
+  const preview = useMemo(
+    () =>
+      buildTournament({
+        name,
+        description,
+        visibility,
+        players: players.map((p) => ({ name: p.name, seed: p.seed ?? undefined, team: p.team, notes: p.notes })),
+      }),
+    [name, description, visibility, players],
+  );
+
+  const handleRandomize = () => {
+    setPlayers(randomizeUnseededPlayers(players));
+  };
+
+  const handleSubmit = async () => {
+    const payload: TournamentSeedData = {
+      name,
+      description,
+      visibility,
+      players: players.map((p) => ({ name: p.name, seed: p.seed ?? undefined, team: p.team, notes: p.notes })),
+    };
+    try {
+      const res = await fetch('/api/tournaments', { method: 'POST', body: JSON.stringify(payload) });
+      if (!res.ok) {
+        const data = await res.json();
+        throw new Error(data.error || 'Unable to create tournament');
+      }
+      const data = await res.json();
+      router.push(`/tournaments/${data.id}/setup`);
+    } catch (err: any) {
+      setError(err.message);
+    }
+  };
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">Create a tournament</h1>
+          <p className="text-zinc-400 text-sm">Set up your players and preview the bracket instantly.</p>
+        </div>
+        <button className="px-4 py-2 bg-green-600 rounded text-white" onClick={handleSubmit}>
+          Save & Continue
+        </button>
+      </div>
+      {error && <div className="text-red-400 text-sm">{error}</div>}
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        <div className="col-span-1 space-y-3">
+          <input
+            className="w-full bg-zinc-900 border border-zinc-700 rounded px-3 py-2"
+            placeholder="Tournament name"
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+          />
+          <textarea
+            className="w-full bg-zinc-900 border border-zinc-700 rounded px-3 py-2"
+            placeholder="Description"
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+          />
+          <label className="text-sm text-zinc-300">Visibility</label>
+          <select
+            className="w-full bg-zinc-900 border border-zinc-700 rounded px-3 py-2"
+            value={visibility}
+            onChange={(e) => setVisibility(e.target.value as 'public' | 'private')}
+          >
+            <option value="public">Public link</option>
+            <option value="private">Private</option>
+          </select>
+          <div className="flex gap-2">
+            <button className="px-3 py-1 bg-blue-600 rounded text-white" onClick={handleRandomize}>
+              Randomize unseeded
+            </button>
+            <button className="px-3 py-1 border border-zinc-600 rounded text-white" onClick={() => setPlayers(players.map((p) => ({ ...p, seed: p.seed })))}>
+              Keep seeds
+            </button>
+          </div>
+          <PlayerEditor players={players} onChange={setPlayers} />
+        </div>
+        <div className="lg:col-span-2">
+          <div className="flex items-center justify-between mb-2">
+            <h2 className="text-xl font-semibold">Live bracket preview</h2>
+            <div className="text-sm text-zinc-400">Bracket size adapts to {preview.players.length} players.</div>
+          </div>
+          <Bracket tournament={preview} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/Bracket.tsx
+++ b/src/components/Bracket.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import React, { useMemo } from 'react';
+import { Match, Player, Tournament } from '@/lib/bracket';
+
+interface BracketProps {
+  tournament: Tournament;
+  editable?: boolean;
+  onScoreChange?: (matchId: string, scoreA: number | null, scoreB: number | null) => void;
+}
+
+const playerLabel = (playerId: string | null, players: Player[]) => {
+  if (!playerId) return 'BYE';
+  const player = players.find((p) => p.id === playerId);
+  if (!player) return 'BYE';
+  const seed = player.seed ? `#${player.seed} ` : '';
+  return `${seed}${player.name}`;
+};
+
+const MatchCard: React.FC<{
+  match: Match;
+  players: Player[];
+  editable?: boolean;
+  onScoreChange?: (matchId: string, scoreA: number | null, scoreB: number | null) => void;
+}> = ({ match, players, editable, onScoreChange }) => {
+  const winner = match.winnerPlayerId;
+  const handleChange = (field: 'A' | 'B', value: string) => {
+    if (!onScoreChange) return;
+    const parsed = value === '' ? null : Number(value);
+    if (Number.isNaN(parsed)) return;
+    const scoreA = field === 'A' ? parsed : match.scoreA;
+    const scoreB = field === 'B' ? parsed : match.scoreB;
+    onScoreChange(match.id, scoreA, scoreB);
+  };
+
+  return (
+    <div className="border border-zinc-700 bg-zinc-900 rounded p-3 mb-3 text-sm w-60">
+      <div className={`flex justify-between items-center ${winner === match.slotAPlayerId ? 'text-green-400' : ''}`}>
+        <span>{playerLabel(match.slotAPlayerId, players)}</span>
+        {editable ? (
+          <input
+            type="number"
+            className="w-14 bg-zinc-800 border border-zinc-700 rounded px-1"
+            value={match.scoreA ?? ''}
+            onChange={(e) => handleChange('A', e.target.value)}
+          />
+        ) : (
+          <span>{match.scoreA ?? '-'}</span>
+        )}
+      </div>
+      <div className={`flex justify-between items-center ${winner === match.slotBPlayerId ? 'text-green-400' : ''}`}>
+        <span>{playerLabel(match.slotBPlayerId, players)}</span>
+        {editable ? (
+          <input
+            type="number"
+            className="w-14 bg-zinc-800 border border-zinc-700 rounded px-1"
+            value={match.scoreB ?? ''}
+            onChange={(e) => handleChange('B', e.target.value)}
+          />
+        ) : (
+          <span>{match.scoreB ?? '-'}</span>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export const Bracket: React.FC<BracketProps> = ({ tournament, editable, onScoreChange }) => {
+  const rounds = useMemo(() => {
+    const grouped = tournament.matches.reduce<Record<number, Match[]>>((acc, match) => {
+      acc[match.roundNumber] = acc[match.roundNumber] || [];
+      acc[match.roundNumber].push(match);
+      return acc;
+    }, {});
+    return Object.keys(grouped)
+      .map((key) => Number(key))
+      .sort((a, b) => a - b)
+      .map((round) => grouped[round].sort((a, b) => a.matchNumber - b.matchNumber));
+  }, [tournament.matches]);
+
+  return (
+    <div className="overflow-auto">
+      <div className="flex gap-4">
+        {rounds.map((matches, idx) => (
+          <div key={idx} className="min-w-[260px]">
+            <div className="text-xs text-zinc-400 mb-2">Round {idx + 1}</div>
+            {matches.map((match) => (
+              <MatchCard key={match.id} match={match} players={tournament.players} editable={editable} onScoreChange={onScoreChange} />
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default Bracket;

--- a/src/components/PlayerEditor.tsx
+++ b/src/components/PlayerEditor.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import React from 'react';
+import { Player } from '@/lib/bracket';
+
+interface PlayerEditorProps {
+  players: Player[];
+  onChange: (players: Player[]) => void;
+}
+
+const PlayerEditor: React.FC<PlayerEditorProps> = ({ players, onChange }) => {
+  const updatePlayer = (id: string, field: keyof Player, value: any) => {
+    onChange(players.map((p) => (p.id === id ? { ...p, [field]: value } : p)));
+  };
+
+  const addPlayer = () => {
+    onChange([
+      ...players,
+      {
+        id: crypto.randomUUID(),
+        name: `Player ${players.length + 1}`,
+      },
+    ]);
+  };
+
+  const removePlayer = (id: string) => {
+    onChange(players.filter((p) => p.id !== id));
+  };
+
+  return (
+    <div className="space-y-2">
+      {players.map((player, idx) => (
+        <div key={player.id} className="grid grid-cols-5 gap-2 items-center">
+          <input
+            className="bg-zinc-900 border border-zinc-700 rounded px-2 py-1 col-span-2"
+            value={player.name}
+            onChange={(e) => updatePlayer(player.id, 'name', e.target.value)}
+            placeholder="Name"
+          />
+          <input
+            className="bg-zinc-900 border border-zinc-700 rounded px-2 py-1"
+            value={player.team ?? ''}
+            onChange={(e) => updatePlayer(player.id, 'team', e.target.value)}
+            placeholder="Team"
+          />
+          <input
+            type="number"
+            className="bg-zinc-900 border border-zinc-700 rounded px-2 py-1"
+            value={player.seed ?? ''}
+            min={1}
+            onChange={(e) => updatePlayer(player.id, 'seed', e.target.value === '' ? null : Number(e.target.value))}
+            placeholder="Seed"
+          />
+          <div className="flex justify-end">
+            <button className="text-red-400 text-sm" onClick={() => removePlayer(player.id)}>
+              Remove
+            </button>
+          </div>
+        </div>
+      ))}
+      <button className="px-3 py-1 bg-blue-600 rounded text-white" onClick={addPlayer}>
+        Add player
+      </button>
+    </div>
+  );
+};
+
+export default PlayerEditor;

--- a/src/hooks/useTournament.ts
+++ b/src/hooks/useTournament.ts
@@ -1,0 +1,40 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Tournament } from '@/lib/bracket';
+
+export const useTournament = (id: string) => {
+  const [tournament, setTournament] = useState<Tournament | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!id) return;
+    const load = async () => {
+      try {
+        const res = await fetch(`/api/tournaments/${id}`);
+        if (!res.ok) throw new Error('Unable to load');
+        const data = await res.json();
+        setTournament(data);
+      } catch (err: any) {
+        setError(err.message);
+      }
+    };
+    load();
+    const eventSource = new EventSource(`/api/tournaments/${id}/events`);
+    eventSource.onmessage = (evt) => {
+      if (!evt.data) return;
+      try {
+        const parsed = JSON.parse(evt.data);
+        setTournament(parsed);
+      } catch (err: any) {
+        setError(err.message);
+      }
+    };
+    eventSource.onerror = () => setError('Connection lost');
+    return () => eventSource.close();
+  }, [id]);
+
+  return { tournament, error };
+};
+
+export default useTournament;

--- a/src/lib/bracket.ts
+++ b/src/lib/bracket.ts
@@ -1,0 +1,268 @@
+const getUUID = () => {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return (crypto as Crypto).randomUUID();
+  }
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { randomUUID } = require('crypto');
+  return randomUUID();
+};
+
+export type TournamentStatus = 'DRAFT' | 'LIVE' | 'COMPLETED';
+
+export interface Player {
+  id: string;
+  name: string;
+  seed?: number | null;
+  team?: string;
+  notes?: string;
+}
+
+export interface Tournament {
+  id: string;
+  name: string;
+  description?: string;
+  startTime?: string;
+  visibility?: 'public' | 'private';
+  status: TournamentStatus;
+  players: Player[];
+  matches: Match[];
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface Match {
+  id: string;
+  tournamentId: string;
+  roundNumber: number;
+  matchNumber: number;
+  slotAPlayerId: string | null;
+  slotBPlayerId: string | null;
+  scoreA: number | null;
+  scoreB: number | null;
+  winnerPlayerId: string | null;
+  nextMatchId: string | null;
+  nextMatchSlot: 'A' | 'B' | null;
+}
+
+export interface TournamentSeedData {
+  name: string;
+  description?: string;
+  startTime?: string;
+  visibility?: 'public' | 'private';
+  players: Omit<Player, 'id'>[];
+}
+
+export const nextPowerOfTwo = (count: number) => {
+  if (count < 2) return 2;
+  return 2 ** Math.ceil(Math.log2(count));
+};
+
+export const generateSeedingOrder = (size: number): number[] => {
+  let order = [1, 2];
+  while (order.length < size) {
+    const next: number[] = [];
+    const currentSize = order.length * 2 + 1;
+    for (const seed of order) {
+      next.push(seed);
+      next.push(currentSize - seed);
+    }
+    order = next;
+  }
+  return order.slice(0, size);
+};
+
+const shuffle = <T,>(arr: T[]) => {
+  const copy = [...arr];
+  for (let i = copy.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [copy[i], copy[j]] = [copy[j], copy[i]];
+  }
+  return copy;
+};
+
+export const placePlayersIntoSlots = (players: Player[], bracketSize: number) => {
+  const seedingOrder = generateSeedingOrder(bracketSize);
+  const slots: (Player | null)[] = Array(bracketSize).fill(null);
+  const seededPlayers = players.filter((p) => p.seed && p.seed > 0);
+  const unseededPlayers = players.filter((p) => !p.seed || p.seed <= 0);
+
+  for (const player of seededPlayers) {
+    const positionIndex = seedingOrder.findIndex((seed) => seed === player.seed);
+    if (positionIndex >= 0) {
+      slots[positionIndex] = player;
+    }
+  }
+
+  const remainingSlots = slots.map((slot, idx) => (slot ? -1 : idx)).filter((v) => v >= 0);
+  const randomized = shuffle(unseededPlayers);
+  remainingSlots.forEach((slotIndex, idx) => {
+    slots[slotIndex] = randomized[idx] ?? null;
+  });
+
+  return slots;
+};
+
+export const generateMatches = (tournamentId: string, bracketSize: number): Match[] => {
+  const rounds = Math.log2(bracketSize);
+  const matches: Match[] = [];
+  for (let round = 1; round <= rounds; round += 1) {
+    const matchesInRound = bracketSize / 2 ** round;
+    for (let m = 0; m < matchesInRound; m += 1) {
+      matches.push({
+        id: getUUID(),
+        tournamentId,
+        roundNumber: round,
+        matchNumber: m,
+        slotAPlayerId: null,
+        slotBPlayerId: null,
+        scoreA: null,
+        scoreB: null,
+        winnerPlayerId: null,
+        nextMatchId: null,
+        nextMatchSlot: null,
+      });
+    }
+  }
+
+  const matchesByRound = matches.reduce<Record<number, Match[]>>((acc, match) => {
+    acc[match.roundNumber] = acc[match.roundNumber] || [];
+    acc[match.roundNumber].push(match);
+    return acc;
+  }, {});
+
+  for (let round = 1; round < rounds; round += 1) {
+    const current = matchesByRound[round];
+    const next = matchesByRound[round + 1];
+    current.forEach((match, idx) => {
+      const target = next[Math.floor(idx / 2)];
+      match.nextMatchId = target.id;
+      match.nextMatchSlot = idx % 2 === 0 ? 'A' : 'B';
+    });
+  }
+
+  return matches;
+};
+
+const pushWinner = (
+  matches: Map<string, Match>,
+  match: Match,
+  winnerId: string | null,
+) => {
+  if (!match.nextMatchId || !match.nextMatchSlot) return;
+  const nextMatch = matches.get(match.nextMatchId);
+  if (!nextMatch) return;
+
+  if (match.nextMatchSlot === 'A') {
+    nextMatch.slotAPlayerId = winnerId;
+  } else {
+    nextMatch.slotBPlayerId = winnerId;
+  }
+
+  if (!winnerId) {
+    nextMatch.scoreA = match.nextMatchSlot === 'A' ? null : nextMatch.scoreA;
+    nextMatch.scoreB = match.nextMatchSlot === 'B' ? null : nextMatch.scoreB;
+    nextMatch.winnerPlayerId = null;
+    pushWinner(matches, nextMatch, null);
+  }
+};
+
+export const buildTournament = (seedData: TournamentSeedData): Tournament => {
+  const bracketSize = nextPowerOfTwo(seedData.players.length || 2);
+  const tournamentId = getUUID();
+  const players: Player[] = seedData.players.map((p) => ({ ...p, id: getUUID() }));
+  const slots = placePlayersIntoSlots(players, bracketSize);
+  const matches = generateMatches(tournamentId, bracketSize);
+  const matchMap = new Map(matches.map((m) => [m.id, m]));
+
+  matches
+    .filter((m) => m.roundNumber === 1)
+    .forEach((match, idx) => {
+      const playerA = slots[idx * 2] ?? null;
+      const playerB = slots[idx * 2 + 1] ?? null;
+      match.slotAPlayerId = playerA ? playerA.id : null;
+      match.slotBPlayerId = playerB ? playerB.id : null;
+
+      if (playerA && !playerB) {
+        match.winnerPlayerId = playerA.id;
+        pushWinner(matchMap, match, playerA.id);
+      } else if (!playerA && playerB) {
+        match.winnerPlayerId = playerB.id;
+        pushWinner(matchMap, match, playerB.id);
+      }
+    });
+
+  const now = new Date().toISOString();
+  return {
+    id: tournamentId,
+    name: seedData.name,
+    description: seedData.description,
+    startTime: seedData.startTime,
+    visibility: seedData.visibility ?? 'public',
+    status: 'DRAFT',
+    players,
+    matches,
+    createdAt: now,
+    updatedAt: now,
+  };
+};
+
+export const recalcFromPlayers = (tournament: Tournament, players: Player[]) => {
+  const updated = buildTournament({
+    name: tournament.name,
+    description: tournament.description,
+    startTime: tournament.startTime,
+    visibility: tournament.visibility,
+    players,
+  });
+  return { ...updated, id: tournament.id, createdAt: tournament.createdAt, status: tournament.status };
+};
+
+export const recordScore = (
+  tournament: Tournament,
+  matchId: string,
+  scoreA: number | null,
+  scoreB: number | null,
+): Tournament => {
+  const matchMap = new Map(tournament.matches.map((m) => [m.id, { ...m }]));
+  const match = matchMap.get(matchId);
+  if (!match) throw new Error('Match not found');
+
+  match.scoreA = scoreA;
+  match.scoreB = scoreB;
+  match.winnerPlayerId = null;
+
+  if (scoreA === null || scoreB === null) {
+    pushWinner(matchMap, match, null);
+    return { ...tournament, matches: Array.from(matchMap.values()) };
+  }
+
+  if (scoreA === scoreB) {
+    throw new Error('Tie scores not supported');
+  }
+
+  const winnerId = scoreA > scoreB ? match.slotAPlayerId : match.slotBPlayerId;
+  match.winnerPlayerId = winnerId ?? null;
+  pushWinner(matchMap, match, winnerId ?? null);
+  return { ...tournament, matches: Array.from(matchMap.values()) };
+};
+
+export const randomizeUnseededPlayers = (players: Player[]) => {
+  const seeded = players.filter((p) => p.seed && p.seed > 0);
+  const unseeded = players.filter((p) => !p.seed || p.seed <= 0);
+  return [...seeded, ...shuffle(unseeded)];
+};
+
+export const regenerateSeeds = (players: Player[]) => {
+  const seeded = players.filter((p) => p.seed && p.seed > 0);
+  const unseeded = players.filter((p) => !p.seed || p.seed <= 0);
+  return [...seeded, ...shuffle(unseeded)];
+};
+
+export const removePlayerProgression = (matches: Map<string, Match>, playerId: string | null) => {
+  if (!playerId) return;
+  matches.forEach((m) => {
+    if (m.slotAPlayerId === playerId) m.slotAPlayerId = null;
+    if (m.slotBPlayerId === playerId) m.slotBPlayerId = null;
+    if (m.winnerPlayerId === playerId) m.winnerPlayerId = null;
+  });
+};

--- a/src/lib/tournamentStore.ts
+++ b/src/lib/tournamentStore.ts
@@ -1,0 +1,103 @@
+import { EventEmitter } from 'events';
+import {
+  Tournament,
+  TournamentSeedData,
+  buildTournament,
+  recalcFromPlayers,
+  recordScore,
+  randomizeUnseededPlayers,
+} from './bracket';
+
+const makeId = () => {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return (crypto as Crypto).randomUUID();
+  }
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { randomUUID } = require('crypto');
+  return randomUUID();
+};
+
+const tournaments = new Map<string, Tournament>();
+const emitters = new Map<string, EventEmitter>();
+
+const getEmitter = (id: string) => {
+  if (!emitters.has(id)) {
+    emitters.set(id, new EventEmitter());
+  }
+  return emitters.get(id)!;
+};
+
+export const createTournament = (seedData: TournamentSeedData) => {
+  const tournament = buildTournament(seedData);
+  tournaments.set(tournament.id, tournament);
+  getEmitter(tournament.id).emit('update', tournament);
+  return tournament;
+};
+
+export const listTournaments = () => Array.from(tournaments.values());
+
+export const getTournament = (id: string) => tournaments.get(id) || null;
+
+export const updateTournamentSetup = (id: string, seedData: TournamentSeedData) => {
+  const current = tournaments.get(id);
+  if (!current) throw new Error('Tournament not found');
+  if (current.status !== 'DRAFT') throw new Error('Tournament locked');
+  const next = recalcFromPlayers({ ...current, status: 'DRAFT' }, seedData.players.map((p: any) => ({ ...p, id: p.id || makeId() })) as any);
+  next.name = seedData.name;
+  next.description = seedData.description;
+  next.startTime = seedData.startTime;
+  next.visibility = seedData.visibility;
+  next.updatedAt = new Date().toISOString();
+  tournaments.set(id, next);
+  getEmitter(id).emit('update', next);
+  return next;
+};
+
+export const shuffleUnseeded = (id: string) => {
+  const current = tournaments.get(id);
+  if (!current) throw new Error('Tournament not found');
+  if (current.status !== 'DRAFT') throw new Error('Tournament locked');
+  const updatedPlayers = randomizeUnseededPlayers(current.players);
+  const next = recalcFromPlayers(current, updatedPlayers);
+  tournaments.set(id, next);
+  getEmitter(id).emit('update', next);
+  return next;
+};
+
+export const startTournament = (id: string) => {
+  const current = tournaments.get(id);
+  if (!current) throw new Error('Tournament not found');
+  const next: Tournament = { ...current, status: 'LIVE', updatedAt: new Date().toISOString() };
+  tournaments.set(id, next);
+  getEmitter(id).emit('update', next);
+  return next;
+};
+
+export const submitScore = (id: string, matchId: string, scoreA: number | null, scoreB: number | null) => {
+  const current = tournaments.get(id);
+  if (!current) throw new Error('Tournament not found');
+  if (current.status !== 'LIVE') throw new Error('Tournament not live');
+  const next = recordScore(current, matchId, scoreA, scoreB);
+  tournaments.set(id, next);
+  getEmitter(id).emit('update', next);
+  return next;
+};
+
+export const resetScore = (id: string, matchId: string) => submitScore(id, matchId, null, null);
+
+export const subscribe = (id: string, cb: (t: Tournament) => void) => {
+  const emitter = getEmitter(id);
+  emitter.on('update', cb);
+  return () => emitter.off('update', cb);
+};
+
+export const seedDemo = () => {
+  if (tournaments.size > 0) return;
+  const demo = createTournament({
+    name: 'Demo Bracket',
+    description: 'Example bracket ready to edit',
+    visibility: 'public',
+    players: Array.from({ length: 8 }).map((_, idx) => ({ name: `Player ${idx + 1}`, seed: idx < 4 ? idx + 1 : undefined })),
+  });
+  tournaments.set(demo.id, demo);
+};

--- a/tests/bracket.test.ts
+++ b/tests/bracket.test.ts
@@ -1,0 +1,56 @@
+import assert from 'assert';
+const { buildTournament, recordScore, nextPowerOfTwo } = require('../src/lib/bracket');
+
+type SimplePlayer = { name: string; seed?: number };
+
+const makeTournament = (players: SimplePlayer[]) =>
+  buildTournament({ name: 'Test', players: players.map((p) => ({ ...p })) });
+
+// Test bracket sizing
+const size10 = nextPowerOfTwo(10);
+assert.strictEqual(size10, 16, 'Next power of two should be 16');
+
+// Test seeding placement keeps top seed apart
+const tourney = makeTournament([
+  { name: 'Seed1', seed: 1 },
+  { name: 'Seed2', seed: 2 },
+  { name: 'Seed3', seed: 3 },
+  { name: 'Seed4', seed: 4 },
+]);
+const roundOneMatches = tourney.matches.filter((m: any) => m.roundNumber === 1);
+const matchWithSeed1 = roundOneMatches.find(
+  (m: any) => m.slotAPlayerId === tourney.players[0].id || m.slotBPlayerId === tourney.players[0].id,
+);
+const matchWithSeed2 = roundOneMatches.find(
+  (m: any) => m.slotAPlayerId === tourney.players[1].id || m.slotBPlayerId === tourney.players[1].id,
+);
+assert.ok(matchWithSeed1 && matchWithSeed2 && matchWithSeed1.id !== matchWithSeed2.id, 'Top seeds should not meet in round one');
+
+// Test BYE auto-advance
+const uneven = makeTournament([
+  { name: 'Alpha', seed: 1 },
+  { name: 'Beta', seed: 2 },
+  { name: 'Gamma', seed: 3 },
+]);
+const byeMatch = uneven.matches.find((m: any) => m.roundNumber === 1 && (!m.slotAPlayerId || !m.slotBPlayerId));
+assert.ok(byeMatch?.winnerPlayerId, 'BYE should auto-advance player');
+
+// Test score advancement and rollback
+const playable = makeTournament([
+  { name: 'A' },
+  { name: 'B' },
+  { name: 'C' },
+  { name: 'D' },
+]);
+const firstMatch = playable.matches.find((m: any) => m.roundNumber === 1 && m.matchNumber === 0)!;
+const afterScore = recordScore(playable, firstMatch.id, 3, 1);
+const propagated = afterScore.matches.find((m: any) => m.id === firstMatch.nextMatchId)!;
+assert.strictEqual(
+  propagated.slotAPlayerId || propagated.slotBPlayerId,
+  afterScore.players.find((p: any) => p.id === firstMatch.slotAPlayerId)?.id,
+);
+const rollback = recordScore(afterScore, firstMatch.id, null, null);
+const cleaned = rollback.matches.find((m: any) => m.id === firstMatch.nextMatchId)!;
+assert.ok(!cleaned.slotAPlayerId || !cleaned.slotBPlayerId, 'Rollback should clear progression');
+
+console.log('All bracket logic tests passed');


### PR DESCRIPTION
## Summary
- add in-memory tournament store, bracket generation utilities, and SSE endpoints for live updates
- create setup, live scoring, and viewer pages with bracket rendering and BYE-aware previews
- add reusable player editor and bracket components plus navigation link back to main site

## Testing
- TS_NODE_COMPILER_OPTIONS='{"module":"CommonJS"}' node -r ts-node/register tests/bracket.test.ts

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f8332c714832c9a0e4cf8898aa3f6)