### PR TITLE
Add admin asterisk selection to flag player scores

### DIFF
--- a/src/app/Admin/adminPage.module.css
+++ b/src/app/Admin/adminPage.module.css
@@ -133,6 +133,19 @@
   margin-bottom: 20px;
 }
 
+.asteriskButton {
+  font-size: 2rem;
+  padding: 8px 16px;
+  line-height: 1;
+  border: 2px solid #2a9d8f;
+}
+
+.asteriskButtonActive {
+  background-color: #2a9d8f;
+  color: #fff;
+  box-shadow: 0 0 0 3px rgba(42, 157, 143, 0.2);
+}
+
 .arrow {
   margin-left: 10px;
 }

--- a/src/app/Admin/page.tsx
+++ b/src/app/Admin/page.tsx
@@ -12,7 +12,8 @@ import { User } from '@supabase/supabase-js';
 interface Player {
   player_id: number;
   name: string;
-  is_hidden: boolean; 
+  is_hidden: boolean;
+  has_asterisk?: boolean;
 }
 
 interface TierWithPlayers {
@@ -62,6 +63,7 @@ const AdminPage = () => {
   const [isAdmin, setIsAdmin] = useState<boolean>(false); // Admin check
   const [seasonName, setSeasonName] = useState<string>(''); // Active season name
   const [userView, setUserView] = useState<string>(''); // User's current view setting
+  const [isAsteriskMode, setIsAsteriskMode] = useState<boolean>(false);
 
   const pageOptions = ['Standings', 'FreeAgent', 'Rules'];
 
@@ -116,7 +118,8 @@ const AdminPage = () => {
           players (
             player_id,
             name,
-            is_hidden
+            is_hidden,
+            has_asterisk
           )
         `);
 
@@ -182,6 +185,30 @@ const AdminPage = () => {
     setSelectedName(name);
     setSelectedPlayerId(playerId);
     setIsModalOpen(true);
+  };
+
+  const handleToggleAsteriskMode = () => {
+    setIsAsteriskMode((prev) => !prev);
+  };
+
+  const handleTogglePlayerAsterisk = async (
+    playerId: number,
+    currentHasAsterisk: boolean | undefined,
+  ) => {
+    try {
+      const { error } = await supabase
+        .from('players')
+        .update({ has_asterisk: !currentHasAsterisk })
+        .eq('player_id', playerId);
+
+      if (error) {
+        console.error('Error updating asterisk status:', error);
+      }
+    } catch (err) {
+      console.error('Unexpected error toggling asterisk:', err);
+    } finally {
+      setIsAsteriskMode(false);
+    }
   };
 
   const handleCloseModal = () => {
@@ -284,6 +311,16 @@ const AdminPage = () => {
             <button className={styles.button} onClick={handleOpenSidebar}>
               Settings
             </button>
+            <button
+              className={`${styles.button} ${styles.asteriskButton} ${
+                isAsteriskMode ? styles.asteriskButtonActive : ''
+              }`}
+              onClick={handleToggleAsteriskMode}
+              aria-pressed={isAsteriskMode}
+              aria-label="Toggle asterisk selection mode"
+            >
+              *
+            </button>
 
             {/* Dropdown for Page Options */}
             <select
@@ -312,7 +349,11 @@ const AdminPage = () => {
           <div
             key={player.player_id}
             className={styles.box}
-            onClick={() => handleOpenModal(player.player_id, player.name)}
+            onClick={() =>
+              isAsteriskMode
+                ? handleTogglePlayerAsterisk(player.player_id, player.has_asterisk)
+                : handleOpenModal(player.player_id, player.name)
+            }
             style={{ color: tier.color }}
           >
             {player.name}

--- a/src/app/Standings/page.tsx
+++ b/src/app/Standings/page.tsx
@@ -30,6 +30,7 @@ interface TeamWithPlayers {
     player_score: number;
     pps: number;
     reached_score_at: string | null;
+    has_asterisk?: boolean;
   }[];
   team_pps: number;
   total_shots: number;
@@ -297,6 +298,7 @@ const StandingsPage: React.FC = () => {
                 shots_made_in_row: shotsMadeInRow,
                 shots_missed_in_row: shotsMissedInRow,
                 reached_score_at: reachedScoreAt,
+                has_asterisk: player.has_asterisk,
               };
             })
           );
@@ -589,8 +591,11 @@ const timeUntilMidnight = midnight.getTime() - now.getTime();
                       </div>
                     </div>
                     {/* Player Stats */}
-                    <span className={styles.shotsLeft}>{player.shots_left}</span>
-                  <span className={styles.totalPoints}>{player.player_score}</span>
+                  <span className={styles.shotsLeft}>{player.shots_left}</span>
+                  <span className={styles.totalPoints}>
+                    {player.player_score}
+                    {player.has_asterisk ? '*' : ''}
+                  </span>
                   <span className={styles.pps}>{player.pps.toFixed(2)}</span>
                 </div>
               ))}

--- a/supabase/migrations/20250604120000_add_player_asterisk_flag.sql
+++ b/supabase/migrations/20250604120000_add_player_asterisk_flag.sql
@@ -1,0 +1,3 @@
+-- Add a persistent asterisk flag for players
+ALTER TABLE IF EXISTS public.players
+ADD COLUMN IF NOT EXISTS has_asterisk boolean DEFAULT false;


### PR DESCRIPTION
## Summary
- add an asterisk toggle mode to the admin dashboard with a dedicated button
- persist player asterisk state in the database and reuse it across views
- display the asterisk next to marked players’ total scores on the standings page

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f8e0470c0832caaed20c80c08db58)