### PR TITLE
Add admin toggle for player score asterisks

### DIFF
--- a/src/app/Standings/StandingsPage.module.css
+++ b/src/app/Standings/StandingsPage.module.css
@@ -89,6 +89,12 @@
   text-align: center;
 }
 
+.asterisk {
+  margin-left: 4px;
+  color: #f59e0b;
+  font-weight: 700;
+}
+
 /* Ensure that the columns are evenly spaced and aligned */
 .columnHeader {
   flex-basis: 25%;

--- a/src/app/Standings/page.tsx
+++ b/src/app/Standings/page.tsx
@@ -28,6 +28,7 @@ interface TeamWithPlayers {
     name: string;
     shots_left: number;
     player_score: number;
+    has_asterisk?: boolean;
     pps: number;
     reached_score_at: string | null;
   }[];
@@ -273,7 +274,7 @@ const StandingsPage: React.FC = () => {
             players.map(async (player: any) => {
               const { data: playerInstance, error: piError } = await supabase
                 .from('player_instance')
-                .select('player_instance_id, shots_left, score')
+                .select('player_instance_id, shots_left, score, has_asterisk')
                 .eq('player_id', player.player_id)
                 .eq('season_id', activeSeasonId)
                 .single();
@@ -291,6 +292,7 @@ const StandingsPage: React.FC = () => {
                 name: player.name,
                 shots_left: playerInstance.shots_left,
                 player_score: playerInstance.score,
+                has_asterisk: playerInstance.has_asterisk,
                 shots_taken: shotsTaken,
                 pps: shotsTaken > 0 ? playerInstance.score / shotsTaken : 0,
                 tier_color: player.tiers?.color || '#000',
@@ -590,7 +592,10 @@ const timeUntilMidnight = midnight.getTime() - now.getTime();
                     </div>
                     {/* Player Stats */}
                     <span className={styles.shotsLeft}>{player.shots_left}</span>
-                  <span className={styles.totalPoints}>{player.player_score}</span>
+                  <span className={styles.totalPoints}>
+                    {player.player_score}
+                    {player.has_asterisk && <span className={styles.asterisk}>*</span>}
+                  </span>
                   <span className={styles.pps}>{player.pps.toFixed(2)}</span>
                 </div>
               ))}

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -27,6 +27,7 @@ const Modal: React.FC<ModalProps> = ({ name, isOpen, onClose, playerId }) => {
   const [tierId, setTierId] = useState<number | null>(null); // Tier ID of the player
   const [shotsLeft, setShotsLeft] = useState<number | null>(null); // Remaining shots for the player
   const [shotsTakenToday, setShotsTakenToday] = useState<number | null>(null); // Shots taken in the current calendar day
+  const [hasAsterisk, setHasAsterisk] = useState<boolean>(false); // Whether the player's score is flagged with an asterisk
   const sound = new Howl({ src: ['/sounds/shot.mp3'] }); // Sound effect for shots
   const shotSound = useMemo(() => new Howl({ src: ['/sounds/onfire.mp3'] }), []);
   const sadsound = useMemo(() => new Howl({ src: ['/sounds/sadtrombone.mp3'] }), []); // Sound effect for sad events
@@ -45,6 +46,7 @@ const Modal: React.FC<ModalProps> = ({ name, isOpen, onClose, playerId }) => {
     setTierId(null);
     setShotsLeft(null);
     setShotsTakenToday(null);
+    setHasAsterisk(false);
   };
   const calculateShotsMadeInRow = async (playerInstanceId: number) => {
     try {
@@ -169,7 +171,7 @@ const Modal: React.FC<ModalProps> = ({ name, isOpen, onClose, playerId }) => {
       // Fetch player instance details
       const { data: playerInstance, error: instanceError } = await supabase
         .from('player_instance')
-        .select('player_instance_id, score, shots_left')
+        .select('player_instance_id, score, shots_left, has_asterisk')
         .eq('player_id', playerId)
         .eq('season_id', currentSeason.season_id)
         .single();
@@ -183,6 +185,7 @@ const Modal: React.FC<ModalProps> = ({ name, isOpen, onClose, playerId }) => {
       setPlayerInstanceId(playerInstance.player_instance_id);
       setCurrentScore(playerInstance.score);
       setShotsLeft(playerInstance.shots_left);
+      setHasAsterisk(Boolean(playerInstance.has_asterisk));
       fetchShotsTakenToday(playerInstance.player_instance_id);
 
       // Fetch the player's tier ID
@@ -299,6 +302,31 @@ const Modal: React.FC<ModalProps> = ({ name, isOpen, onClose, playerId }) => {
     }
   };
 
+  /**
+   * Toggles the asterisk flag for the player's score.
+   */
+  const handleToggleAsterisk = async () => {
+    if (!playerInstanceId) return;
+
+    try {
+      const { data, error } = await supabase
+        .from('player_instance')
+        .update({ has_asterisk: !hasAsterisk })
+        .eq('player_instance_id', playerInstanceId)
+        .select('has_asterisk')
+        .single();
+
+      if (error) {
+        console.error('Error updating asterisk flag:', error);
+        return;
+      }
+
+      setHasAsterisk(Boolean(data?.has_asterisk));
+    } catch (error) {
+      console.error('Unexpected error toggling asterisk:', error);
+    }
+  };
+
   // Render nothing if the modal is not open
   if (!isOpen) return null;
 
@@ -323,6 +351,12 @@ const Modal: React.FC<ModalProps> = ({ name, isOpen, onClose, playerId }) => {
           <p>
             Shots Taken Today: <span>{shotsTakenToday !== null ? shotsTakenToday : '...'}</span>
           </p>
+          <div className="asterisk-row">
+            <span>Asterisk on score:</span>
+            <button className={hasAsterisk ? 'selected' : ''} onClick={handleToggleAsterisk}>
+              {hasAsterisk ? 'Remove Asterisk' : 'Add Asterisk'}
+            </button>
+          </div>
           {shotsTakenToday === 3 && (
             <p className="waiver-disclaimer">
               <strong>

--- a/src/components/Modal/modal.css
+++ b/src/components/Modal/modal.css
@@ -172,6 +172,13 @@ button.selected:hover {
   margin: 10px;
 }
 
+.asterisk-row {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin: 12px 0;
+}
+
 .waiver-disclaimer {
   margin: 12px 0;
   color: #b00020;


### PR DESCRIPTION
## Summary
- allow admins to toggle an asterisk flag on player scores from the player modal
- surface the asterisk indicator beside player scores on the standings page
- add styling for the new asterisk indicator in admin and standings views

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f90577b38832c8626beafe43fab1d)