### PR TITLE
Improve admin modal and header accessibility

### DIFF
--- a/src/components/CurrentSeason/CurrentSeasonModal.module.css
+++ b/src/components/CurrentSeason/CurrentSeasonModal.module.css
@@ -7,7 +7,9 @@
   background: rgba(0, 0, 0, 0.5);
   display: flex;
   justify-content: center;
-  align-items: center;
+  align-items: flex-start;
+  overflow-y: auto;
+  padding: 20px 12px;
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.3s ease;
@@ -27,12 +29,17 @@
   display: flex;
   flex-direction: column;
   position: relative;
+  max-height: calc(100vh - 64px);
+  overflow: hidden;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
 }
 
 .tabs {
   display: flex;
   justify-content: space-between;
   margin-bottom: 20px;
+  flex-wrap: wrap;
+  gap: 8px;
 }
 
 .tab {
@@ -57,11 +64,34 @@
   overflow-y: auto;
 }
 
+.topCloseBtn {
+  position: sticky;
+  top: 0;
+  align-self: flex-end;
+  background: #ffffff;
+  border: 1px solid #ccc;
+  border-radius: 50%;
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 18px;
+  cursor: pointer;
+  color: #333;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.12);
+  margin-left: auto;
+}
+
 /* Add new styles for the close button at the bottom */
 .bottomBar {
   display: flex;
   justify-content: center;
   padding-top: 20px;
+  position: sticky;
+  bottom: 0;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0) 0%, #fff 30%);
+  padding-bottom: 8px;
 }
 
 .closeBtn {

--- a/src/components/CurrentSeason/CurrentSeasonModal.tsx
+++ b/src/components/CurrentSeason/CurrentSeasonModal.tsx
@@ -37,8 +37,20 @@ const CurrentSeasonModal: React.FC<CurrentSeasonModalProps> = ({ isOpen, onClose
 
   return (
     // Modal container with dynamic class based on `isOpen` prop
-    <div className={`${styles.currentSeasonModal} ${isOpen ? styles.currentSeasonModalOpen : ''}`}>
+    <div
+      className={`${styles.currentSeasonModal} ${isOpen ? styles.currentSeasonModalOpen : ''}`}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Manage current season"
+    >
       <div className={styles.modalContent}>
+        <button
+          className={styles.topCloseBtn}
+          onClick={onClose}
+          aria-label="Close current season controls"
+        >
+          ×
+        </button>
         {/* Tabs for navigating between sections */}
         <div className={styles.tabs}>
           {/* Tab: Adjust Shots */}

--- a/src/components/Header.module.css
+++ b/src/components/Header.module.css
@@ -12,6 +12,7 @@
     display: flex;
     align-items: center;
     gap: 0.25rem;
+    flex-wrap: wrap;
   }
   
   .navItem {
@@ -20,7 +21,9 @@
     border: none;
     font-size: 1rem;
     cursor: pointer;
-    padding: 0.5rem 1rem;
+    padding: 0.25rem 0.5rem;
+    width: 64px;
+    height: 64px;
   }
   /* Navbar styling */
   .navbar {
@@ -33,6 +36,11 @@
     color: white;
     box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
     flex-shrink: 0;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    position: sticky;
+    top: 0;
+    z-index: 1300;
   }
   .active {
     /* inverted color due to needing to invert the logo */
@@ -44,5 +52,33 @@
     font-size: 2rem;
     font-weight: bold;
     margin: 0;
+  }
+
+  @media (max-width: 900px) {
+    .navbarTitle {
+      font-size: 1.5rem;
+    }
+
+    .navItem {
+      width: 52px;
+      height: 52px;
+    }
+  }
+
+  @media (max-width: 640px) {
+    .navbar {
+      justify-content: center;
+    }
+
+    .navMenu {
+      width: 100%;
+      justify-content: center;
+      gap: 0.35rem;
+    }
+
+    .navItem {
+      width: 48px;
+      height: 48px;
+    }
   }
   

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -303,9 +303,20 @@ const Modal: React.FC<ModalProps> = ({ name, isOpen, onClose, playerId }) => {
   if (!isOpen) return null;
 
   return (
-    <div className="modal-overlay" onClick={handleClose}>
-      <div className={`modal-content ${isMoneyball ? 'highlight-modal-border' : ''}`} onClick={(e) => e.stopPropagation()}>
-        <button className="close-button" onClick={handleClose}>X</button>
+    <div
+      className="modal-overlay"
+      onClick={handleClose}
+      role="dialog"
+      aria-modal="true"
+      aria-label={`${name} score modal`}
+    >
+      <div
+        className={`modal-content ${isMoneyball ? 'highlight-modal-border' : ''}`}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <button className="close-button" onClick={handleClose} aria-label="Close player modal">
+          ×
+        </button>
 
         <h2>{name}</h2>
 

--- a/src/components/Modal/modal.css
+++ b/src/components/Modal/modal.css
@@ -8,7 +8,9 @@
   background: rgba(0, 0, 0, 0.5);
   display: flex;
   justify-content: center;
-  align-items: center;
+  align-items: flex-start;
+  overflow-y: auto;
+  padding: 20px 12px;
 }
 .button-row {
   display: flex;
@@ -37,6 +39,11 @@
   color: black;
   width: 520px;
   max-width: 95%;
+  max-height: calc(100vh - 64px);
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 
 .highlight-modal-border {
@@ -138,14 +145,22 @@ button.selected:hover {
 
 /* X Close Button Styles */
 .close-button {
-  position: absolute;
-  top: 10px;
-  right: 10px;
-  background: transparent;
-  border: none;
-  font-size: 20px;
+  position: sticky;
+  top: 0;
+  align-self: flex-end;
+  background: #ffffff;
+  border: 1px solid #ccc;
+  border-radius: 50%;
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 18px;
   cursor: pointer;
   color: black;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.12);
+  margin-left: auto;
 }
 
 .close-button:hover {

--- a/src/components/NextSeason/NextSeason.module.css
+++ b/src/components/NextSeason/NextSeason.module.css
@@ -8,7 +8,9 @@
   background: rgba(0, 0, 0, 0.6); /* Dark background to focus on modal */
   display: flex;
   justify-content: center;
-  align-items: center;
+  align-items: flex-start;
+  overflow-y: auto;
+  padding: 20px 12px;
   z-index: 1100;
 }
 
@@ -21,19 +23,29 @@
   max-width: 600px;
   box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
   overflow-y: auto;
-  max-height: 90vh;
+  max-height: calc(100vh - 64px);
   position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
 }
 
 /* Close Button */
 .closeButton {
-  position: absolute;
-  top: 10px;
-  right: 10px;
-  background: none;
-  border: none;
-  font-size: 24px;
+  position: sticky;
+  top: 0;
+  align-self: flex-end;
+  background: #ffffff;
+  border: 1px solid #ccc;
+  border-radius: 50%;
+  width: 36px;
+  height: 36px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 18px;
   cursor: pointer;
+  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.12);
 }
 
 /* Form Sections */

--- a/src/components/NextSeason/NextSeason.tsx
+++ b/src/components/NextSeason/NextSeason.tsx
@@ -576,7 +576,13 @@ const NextSeasonModal: React.FC<NextSeasonModalProps> = ({ isOpen, onClose, onSt
   if (!isOpen) return null;
 
   return (
-    <div className={styles.modalBackdrop} aria-modal="true" role="dialog" tabIndex={-1}>
+    <div
+      className={styles.modalBackdrop}
+      aria-modal="true"
+      role="dialog"
+      tabIndex={-1}
+      aria-label="Plan next season"
+    >
       <div className={styles.modal}>
         {/* Close button to close the modal */}
         <button onClick={onClose} className={styles.closeButton}>X</button>


### PR DESCRIPTION
## Summary
- make admin modals scrollable within the viewport, add sticky close controls, and apply aria dialog attributes
- ensure current and next season management overlays keep navigation/close controls visible on small screens
- update the navigation header to wrap, scale icons, and stay sticky for easier access on tablets

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f965226b8832c91adc77cfc255056)