### PR TITLE
Add separate visibility controls for admin and standings

### DIFF
--- a/src/app/Admin/page.tsx
+++ b/src/app/Admin/page.tsx
@@ -12,7 +12,7 @@ import { User } from '@supabase/supabase-js';
 interface Player {
   player_id: number;
   name: string;
-  is_hidden: boolean; 
+  is_admin_hidden: boolean;
 }
 
 interface TierWithPlayers {
@@ -105,7 +105,7 @@ const AdminPage = () => {
     };
   }, [router]);
 
-  // 2. Fetch tiers and players (and include is_hidden in the select)
+  // 2. Fetch tiers and players (and include hidden flags in the select)
   useEffect(() => {
     const fetchTiersAndPlayers = async () => {
       const { data: tiersData, error: tiersError } = await supabase
@@ -116,7 +116,7 @@ const AdminPage = () => {
           players (
             player_id,
             name,
-            is_hidden
+            is_admin_hidden
           )
         `);
 
@@ -299,15 +299,15 @@ const AdminPage = () => {
             </select>
           </div>
 
-          {/* 5. Display only players where is_hidden === false */}
+          {/* 5. Display only players where is_admin_hidden === false */}
           <div className={styles.players}>
            {tiers
-  .filter((tier) => tier.players.some((player) => !player.is_hidden))
+  .filter((tier) => tier.players.some((player) => !player.is_admin_hidden))
   .map((tier) => (
     <div key={tier.tier_name} className={styles.column}>
       <div className={styles.header}>{tier.tier_name}</div>
       {tier.players
-        .filter((player) => !player.is_hidden)
+        .filter((player) => !player.is_admin_hidden)
         .map((player) => (
           <div
             key={player.player_id}

--- a/src/app/Standings/page.tsx
+++ b/src/app/Standings/page.tsx
@@ -268,9 +268,11 @@ const StandingsPage: React.FC = () => {
             .select('*, tiers(color)')
             .eq('team_id', team.team_id);
           if (playersError) throw playersError;
-  
+
+          const visiblePlayers = players.filter((player: any) => !player.is_standings_hidden);
+
           const playersWithStats = await Promise.all(
-            players.map(async (player: any) => {
+            visiblePlayers.map(async (player: any) => {
               const { data: playerInstance, error: piError } = await supabase
                 .from('player_instance')
                 .select('player_instance_id, shots_left, score')

--- a/src/app/Stats/page.tsx
+++ b/src/app/Stats/page.tsx
@@ -89,13 +89,13 @@ const StatsPage: React.FC = () => {
       // Step 1: Fetch player data (including hidden status)
       const { data: playersData, error: playersError } = await supabase
         .from('players')
-        .select('player_id, name, is_hidden');
+        .select('player_id, name, is_standings_hidden');
 
       if (playersError) throw playersError;
       if (!playersData) return;
 
-      // Step 2: Filter out hidden players
-      const visiblePlayersData = playersData.filter((p) => !p.is_hidden);
+      // Step 2: Filter out hidden players for the standings view
+      const visiblePlayersData = playersData.filter((p) => !p.is_standings_hidden);
 
       // Step 3: Fetch additional stats from the `stats` table
       const { data: statsData, error: statsError } = await supabase

--- a/src/components/AdjustTeams.module.css
+++ b/src/components/AdjustTeams.module.css
@@ -25,6 +25,10 @@
   flex: 3; /* 3 parts for the player table */
   max-height: 400px;
   overflow-y: auto;
+  background: #ffffff;
+  border-radius: 10px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.08);
+  padding: 12px;
 }
 
 /* 3) Give the team-edit section less space with flex:1 */
@@ -35,6 +39,30 @@
   display: flex;
   flex-direction: column;
   gap: 10px; /* spacing between each team row */
+  background: linear-gradient(180deg, #f9fafb 0%, #f2f4f7 100%);
+  border-radius: 10px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7), 0 4px 12px rgba(0, 0, 0, 0.06);
+  padding: 16px;
+  border: 1px solid #e5e7eb;
+}
+
+.teamEditHeader {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 4px;
+}
+
+.helperText {
+  margin: 0;
+  color: #6b7280;
+  font-size: 0.9rem;
+}
+
+.teamEditGrid {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
 }
 
 .adjustTeams p {
@@ -44,21 +72,27 @@
 }
 
 .adjustTeams .teamRow {
-  display: flex;
-  align-items: center;
-  margin-right: 20px;
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 6px;
+  padding: 10px 12px;
+  background: #fff;
+  border-radius: 8px;
+  border: 1px solid #e5e7eb;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.05);
 }
 
 .adjustTeams .teamRow label {
-  margin-right: 10px;
-  white-space: nowrap;
+  font-weight: 600;
+  color: #374151;
 }
 
 .adjustTeams .teamRow input {
   padding: 5px;
   border: 1px solid #ccc;
   border-radius: 4px;
-  width: 200px; /* You can tweak this if needed */
+  width: 100%;
+  background: #f9fafb;
 }
 
 /* Table styling */
@@ -102,6 +136,14 @@
 .adjustTeams select:focus {
   outline: none;
   border-color: #007BFF;
+}
+
+.checkboxLabel {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-weight: 600;
+  color: #374151;
 }
 
 .adjustTeams input[type="text"] {

--- a/src/components/AdjustTeams.tsx
+++ b/src/components/AdjustTeams.tsx
@@ -3,7 +3,7 @@
  *
  * This component provides an interface to manage teams and players. Administrators can:
  * - Edit player names, assign players to teams, or mark players as free agents.
- * - Toggle player visibility (`is_hidden`).
+ * - Toggle player visibility for the admin and standings views.
  * - Edit team names.
  * - View all players and teams in a table format.
  *
@@ -27,7 +27,7 @@ const AdjustTeams: React.FC<AdjustTeamsProps> = ({ isOpen }) => {
 
   /**
    * Fetch players and teams when the component is opened.
-   * - Players include `player_id`, `name`, `team_id`, and `is_hidden`.
+ * - Players include `player_id`, `name`, `team_id`, `is_admin_hidden`, and `is_standings_hidden`.
    * - Teams include all available team data.
    */
   useEffect(() => {
@@ -39,7 +39,7 @@ const AdjustTeams: React.FC<AdjustTeamsProps> = ({ isOpen }) => {
         // Fetch players
         const { data: playerData, error: playerError } = await supabase
           .from('players')
-          .select('player_id, name, team_id, is_hidden');
+          .select('player_id, name, team_id, is_admin_hidden, is_standings_hidden');
 
         if (playerError) {
           console.error('Error fetching players:', playerError);
@@ -138,22 +138,27 @@ const AdjustTeams: React.FC<AdjustTeamsProps> = ({ isOpen }) => {
   };
 
   /**
-   * Toggles a player's visibility (`is_hidden`).
+   * Toggles a player's visibility for the admin or standings views.
    *
    * @param playerId - The ID of the player being updated.
-   * @param newIsHidden - The new visibility status.
+   * @param field - The column to update.
+   * @param value - The new visibility status.
    */
-  const handleIsHiddenChange = async (playerId: number, newIsHidden: boolean) => {
+  const handleVisibilityChange = async (
+    playerId: number,
+    field: 'is_admin_hidden' | 'is_standings_hidden',
+    value: boolean,
+  ) => {
     // Update players locally
     const updatedPlayers = players.map((player) =>
-      player.player_id === playerId ? { ...player, is_hidden: newIsHidden } : player
+      player.player_id === playerId ? { ...player, [field]: value } : player
     );
     setPlayers(updatedPlayers);
 
     // Update the backend
     const { error } = await supabase
       .from('players')
-      .update({ is_hidden: newIsHidden })
+      .update({ [field]: value })
       .eq('player_id', playerId);
 
     if (error) {
@@ -201,7 +206,8 @@ const AdjustTeams: React.FC<AdjustTeamsProps> = ({ isOpen }) => {
                 <tr>
                   <th>Player</th>
                   <th>Team</th>
-                  <th>Hidden?</th>
+                  <th>Admin Hidden?</th>
+                  <th>Standings Hidden?</th>
                 </tr>
               </thead>
               <tbody>
@@ -234,20 +240,38 @@ const AdjustTeams: React.FC<AdjustTeamsProps> = ({ isOpen }) => {
                         </select>
                       </td>
                       <td>
-                        <label>
+                        <label className={styles.checkboxLabel}>
                           <input
                             type="checkbox"
-                            checked={player.is_hidden || false}
-                            onChange={(e) => handleIsHiddenChange(player.player_id, e.target.checked)}
+                            checked={player.is_admin_hidden || false}
+                            onChange={(e) =>
+                              handleVisibilityChange(player.player_id, 'is_admin_hidden', e.target.checked)
+                            }
                           />
-                          Hidden
+                          Admin
+                        </label>
+                      </td>
+                      <td>
+                        <label className={styles.checkboxLabel}>
+                          <input
+                            type="checkbox"
+                            checked={player.is_standings_hidden || false}
+                            onChange={(e) =>
+                              handleVisibilityChange(
+                                player.player_id,
+                                'is_standings_hidden',
+                                e.target.checked,
+                              )
+                            }
+                          />
+                          Standings
                         </label>
                       </td>
                     </tr>
                   ))
                 ) : (
                   <tr>
-                    <td colSpan={3}>No players found</td>
+                    <td colSpan={4}>No players found</td>
                   </tr>
                 )}
               </tbody>
@@ -256,22 +280,27 @@ const AdjustTeams: React.FC<AdjustTeamsProps> = ({ isOpen }) => {
 
           {/* Edit Team Names Section */}
           <div className={styles['team-edit-container']}>
-            <h3>Edit Team Names</h3>
-            {teams.length > 0 ? (
-              teams.map((team) => (
-                <div key={team.team_id} className={styles.teamRow}>
-                  <label htmlFor={`team-${team.team_id}`}>{team.team_name}</label>
-                  <input
-                    id={`team-${team.team_id}`}
-                    type="text"
-                    value={team.team_name || 'Unknown Team'}
-                    onChange={(e) => handleTeamNameChange(team.team_id, e.target.value)}
-                  />
-                </div>
-              ))
-            ) : (
-              <p>No teams available to edit.</p>
-            )}
+            <div className={styles.teamEditHeader}>
+              <h3>Edit Team Names</h3>
+              <p className={styles.helperText}>Rename teams quickly. Changes save automatically.</p>
+            </div>
+            <div className={styles.teamEditGrid}>
+              {teams.length > 0 ? (
+                teams.map((team) => (
+                  <div key={team.team_id} className={styles.teamRow}>
+                    <label htmlFor={`team-${team.team_id}`}>{team.team_name}</label>
+                    <input
+                      id={`team-${team.team_id}`}
+                      type="text"
+                      value={team.team_name || 'Unknown Team'}
+                      onChange={(e) => handleTeamNameChange(team.team_id, e.target.value)}
+                    />
+                  </div>
+                ))
+              ) : (
+                <p>No teams available to edit.</p>
+              )}
+            </div>
           </div>
         </div>
       )}

--- a/src/components/NextSeason/EditPlayerModal.tsx
+++ b/src/components/NextSeason/EditPlayerModal.tsx
@@ -35,7 +35,8 @@ const EditPlayerModal: React.FC<EditPlayerModalProps> = ({
   const [tierId, setTierId] = useState<number>(player?.tier_id || tiers[0]?.tier_id); // Player's tier
   const [teamId, setTeamId] = useState<number>(player?.team_id || teams[0]?.team_id); // Player's team
   const [isFreeAgent, setIsFreeAgent] = useState<boolean>(player?.is_free_agent || false); // Free agent status
-  const [isHidden, setIsHidden] = useState<boolean>(player?.is_hidden || false); // Hidden status
+  const [isAdminHidden, setIsAdminHidden] = useState<boolean>(player?.is_admin_hidden || false); // Admin hidden status
+  const [isStandingsHidden, setIsStandingsHidden] = useState<boolean>(player?.is_standings_hidden || false); // Standings hidden status
 
   /**
    * Effect: Initialize player details when the player prop changes.
@@ -46,7 +47,8 @@ const EditPlayerModal: React.FC<EditPlayerModalProps> = ({
       setTierId(player.tier_id);
       setTeamId(player.team_id);
       setIsFreeAgent(player.is_free_agent);
-      setIsHidden(player.is_hidden);
+      setIsAdminHidden(player.is_admin_hidden);
+      setIsStandingsHidden(player.is_standings_hidden);
     }
   }, [player, teams]);
 
@@ -62,7 +64,8 @@ const EditPlayerModal: React.FC<EditPlayerModalProps> = ({
         tier_id: tierId,
         team_id: isFreeAgent ? null : teamId, // Set team_id to null if player is a free agent
         is_free_agent: isFreeAgent,
-        is_hidden: isHidden, // Update hidden status
+        is_admin_hidden: isAdminHidden,
+        is_standings_hidden: isStandingsHidden,
       })
       .eq('player_id', player.player_id);
 
@@ -77,7 +80,8 @@ const EditPlayerModal: React.FC<EditPlayerModalProps> = ({
       tier_id: tierId,
       team_id: isFreeAgent ? null : teamId,
       is_free_agent: isFreeAgent,
-      is_hidden: isHidden,
+      is_admin_hidden: isAdminHidden,
+      is_standings_hidden: isStandingsHidden,
     });
 
     onClose(); // Close the modal after saving
@@ -146,15 +150,23 @@ const EditPlayerModal: React.FC<EditPlayerModalProps> = ({
             </label>
           </div>
 
-          {/* Hidden Player Checkbox */}
-          <div>
+          {/* Hidden Player Checkboxes */}
+          <div className={styles.checkboxGroup}>
             <label>
               <input
                 type="checkbox"
-                checked={isHidden}
-                onChange={() => setIsHidden(!isHidden)}
+                checked={isAdminHidden}
+                onChange={() => setIsAdminHidden(!isAdminHidden)}
               />
-              Hide Player
+              Hide from Admin
+            </label>
+            <label>
+              <input
+                type="checkbox"
+                checked={isStandingsHidden}
+                onChange={() => setIsStandingsHidden(!isStandingsHidden)}
+              />
+              Hide from Standings
             </label>
           </div>
 

--- a/src/components/NextSeason/NextSeason.module.css
+++ b/src/components/NextSeason/NextSeason.module.css
@@ -226,6 +226,12 @@
   margin-right: 10px;
 }
 
+.checkboxGroup {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
 /* Scrollable lists in modal */
 .scrollableList {
   max-height: 150px; /* Set a reasonable max height */

--- a/supabase/migrations/20250224120000_add_admin_and_standings_hidden.sql
+++ b/supabase/migrations/20250224120000_add_admin_and_standings_hidden.sql
@@ -1,0 +1,5 @@
+ALTER TABLE IF EXISTS public.players
+  ADD COLUMN IF NOT EXISTS is_admin_hidden boolean DEFAULT FALSE;
+
+ALTER TABLE IF EXISTS public.players
+  ADD COLUMN IF NOT EXISTS is_standings_hidden boolean DEFAULT FALSE;


### PR DESCRIPTION
## Summary
- add admin and standings visibility flags for players and wire them into admin, standings, and stats views
- enhance team/player edit UI with clearer layout and dual visibility toggles
- allow next-season player editor to manage the new visibility flags and add database migration for the new columns

## Testing
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693f9b6ec3f4832ca24dfb46232fdf19)