### PR TITLE
Adjust admin modal layout for scoring controls

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -318,7 +318,7 @@ const Modal: React.FC<ModalProps> = ({ name, isOpen, onClose, playerId }) => {
           ×
         </button>
 
-        <h2>{name}</h2>
+        <h2 className="modal-title">{name}</h2>
 
         {/* Moneyball Indicator */}
         {isMoneyball && (
@@ -328,29 +328,31 @@ const Modal: React.FC<ModalProps> = ({ name, isOpen, onClose, playerId }) => {
         )}
 
         <div className="modal-body">
-          <p className={isMoneyball ? 'highlight-moneyball' : ''}>
-            Shots Left: <span>{shotsLeft !== null ? shotsLeft : ''}</span>
-          </p>
-          <p>
-            Shots Taken Today: <span>{shotsTakenToday !== null ? shotsTakenToday : '...'}</span>
-          </p>
-          {shotsTakenToday === 3 && (
-            <p className="waiver-disclaimer">
-              <strong>
-                You are logging your 4th shot, any additional shots today will be waiver attempts. For a waiver
-                attempt you get only one die to roll, no practice shot, and you sacrifice your second attempt.
-              </strong>
+          <div className="score-section">
+            <p className={isMoneyball ? 'highlight-moneyball' : ''}>
+              Shots Left: <span>{shotsLeft !== null ? shotsLeft : ''}</span>
             </p>
-          )}
-          <div className="points">
-            <button className={points === 0 ? 'selected' : ''} onClick={() => setPoints(0)}>0</button>
-            <button className={points === 1 ? 'selected' : ''} onClick={() => setPoints(1)}>1</button>
-            <button className={points === 2 ? 'selected' : ''} onClick={() => setPoints(2)}>2</button>
+            <p>
+              Shots Taken Today: <span>{shotsTakenToday !== null ? shotsTakenToday : '...'}</span>
+            </p>
+            {shotsTakenToday === 3 && (
+              <p className="waiver-disclaimer">
+                <strong>
+                  You are logging your 4th shot, any additional shots today will be waiver attempts. For a waiver
+                  attempt you get only one die to roll, no practice shot, and you sacrifice your second attempt.
+                </strong>
+              </p>
+            )}
+            <div className="points">
+              <button className={points === 0 ? 'selected' : ''} onClick={() => setPoints(0)}>0</button>
+              <button className={points === 1 ? 'selected' : ''} onClick={() => setPoints(1)}>1</button>
+              <button className={points === 2 ? 'selected' : ''} onClick={() => setPoints(2)}>2</button>
+            </div>
+            <div className="actions">
+              <button className={isDouble ? 'selected' : ''} onClick={() => setIsDouble(!isDouble)}>Double</button>
+            </div>
+            <button className="submit-button" onClick={handleSubmit}>Submit</button>
           </div>
-          <div className="actions">
-            <button className={isDouble ? 'selected' : ''} onClick={() => setIsDouble(!isDouble)}>Double</button>
-          </div>
-          <button onClick={handleSubmit}>Submit</button>
         </div>
       </div>
     </div>

--- a/src/components/Modal/modal.css
+++ b/src/components/Modal/modal.css
@@ -33,7 +33,7 @@
 .modal-content {
   position: relative; /* To position the X button */
   background: white;
-  padding: 32px;
+  padding: 24px 32px 32px;
   border-radius: 16px;
   text-align: center;
   color: black;
@@ -42,9 +42,16 @@
   overflow-y: auto;
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 12px;
   box-shadow: 0 12px 32px rgba(0, 0, 0, 0.18);
   font-size: 1.1rem;
+}
+
+.modal-title {
+  margin: 4px auto 8px;
+  font-size: 1.8rem;
+  font-weight: 700;
+  text-align: center;
 }
 
 .highlight-modal-border {
@@ -53,20 +60,33 @@
 
 .modal-body {
   display: flex;
+  flex-direction: row;
+  align-items: flex-start;
+  justify-content: flex-start;
+  gap: 28px;
+  width: 100%;
+}
+
+.score-section {
+  display: flex;
   flex-direction: column;
-  align-items: center;
+  align-items: flex-start;
   gap: 12px;
+  width: 100%;
+  max-width: 460px;
+  text-align: left;
 }
 
 /* General button styles */
 .modal-content button {
   background-color: #f0f0f0;
   border: 1px solid #ccc;
-  padding: 14px 22px;
+  padding: 16px 28px;
   cursor: pointer;
   transition: box-shadow 0.2s ease-in-out, background-color 0.2s ease-in-out;
-  font-size: 1.05rem;
-  border-radius: 10px;
+  font-size: 1.15rem;
+  border-radius: 12px;
+  min-width: 72px;
 }
 .moneyball-indicator {
   display: flex;
@@ -184,12 +204,24 @@
 }
 
 /* Points buttons */
-.points button {
-  margin: 10px;
+.points {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  justify-content: flex-start;
+  width: 100%;
 }
 
-.actions button {
-  margin: 10px;
+.actions {
+  display: flex;
+  gap: 12px;
+  justify-content: flex-start;
+  width: 100%;
+}
+
+.submit-button {
+  align-self: flex-start;
+  padding-inline: 32px;
 }
 
 .waiver-disclaimer {


### PR DESCRIPTION
## Summary
- Center the player name near the top of the modal with larger, bolder styling
- Align the scoring controls to the left within a dedicated section to leave room for future instructions
- Enlarge modal buttons for better legibility and interaction

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942999d3188832c9e754491aab551aa)