### PR TITLE
Add shot rule displays to admin modal

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -32,6 +32,26 @@ const Modal: React.FC<ModalProps> = ({ name, isOpen, onClose, playerId }) => {
   const sadsound = useMemo(() => new Howl({ src: ['/sounds/sadtrombone.mp3'] }), []); // Sound effect for sad events
   const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
 
+  const standardRules = useMemo(
+    () => ({ dice: 2, practice: 1, attempts: 2 }),
+    [],
+  );
+
+  const waiverRules = useMemo(
+    () => ({ dice: 1, practice: 0, attempts: 1 }),
+    [],
+  );
+
+  const currentRuleType = useMemo(() => {
+    if (shotsTakenToday === null) return 'Standard';
+    return shotsTakenToday >= 4 ? 'Waiver' : 'Standard';
+  }, [shotsTakenToday]);
+
+  const nextRuleType = useMemo(() => {
+    if (shotsTakenToday === null) return 'Standard';
+    return shotsTakenToday >= 3 ? 'Waiver' : 'Standard';
+  }, [shotsTakenToday]);
+
 
 
   /**
@@ -352,6 +372,46 @@ const Modal: React.FC<ModalProps> = ({ name, isOpen, onClose, playerId }) => {
               <button className={isDouble ? 'selected' : ''} onClick={() => setIsDouble(!isDouble)}>Double</button>
             </div>
             <button className="submit-button" onClick={handleSubmit}>Submit</button>
+          </div>
+
+          <div className="rules-section">
+            <div className={`rule-card ${currentRuleType === 'Waiver' ? 'rule-card-waiver' : ''}`}>
+              <p className="rule-heading">Current Shot Rules</p>
+              <p className="rule-tag">{currentRuleType}</p>
+              <ul>
+                <li>
+                  <span>Dice</span>
+                  <strong>{(currentRuleType === 'Standard' ? standardRules : waiverRules).dice}</strong>
+                </li>
+                <li>
+                  <span>Practice</span>
+                  <strong>{(currentRuleType === 'Standard' ? standardRules : waiverRules).practice}</strong>
+                </li>
+                <li>
+                  <span>Attempts</span>
+                  <strong>{(currentRuleType === 'Standard' ? standardRules : waiverRules).attempts}</strong>
+                </li>
+              </ul>
+            </div>
+
+            <div className={`rule-card ${nextRuleType === 'Waiver' ? 'rule-card-waiver' : ''}`}>
+              <p className="rule-heading">Next Shot Rules</p>
+              <p className="rule-tag">{nextRuleType}</p>
+              <ul>
+                <li>
+                  <span>Dice</span>
+                  <strong>{(nextRuleType === 'Standard' ? standardRules : waiverRules).dice}</strong>
+                </li>
+                <li>
+                  <span>Practice</span>
+                  <strong>{(nextRuleType === 'Standard' ? standardRules : waiverRules).practice}</strong>
+                </li>
+                <li>
+                  <span>Attempts</span>
+                  <strong>{(nextRuleType === 'Standard' ? standardRules : waiverRules).attempts}</strong>
+                </li>
+              </ul>
+            </div>
           </div>
         </div>
       </div>

--- a/src/components/Modal/modal.css
+++ b/src/components/Modal/modal.css
@@ -65,6 +65,7 @@
   justify-content: flex-start;
   gap: 28px;
   width: 100%;
+  flex-wrap: wrap;
 }
 
 .score-section {
@@ -73,7 +74,7 @@
   align-items: flex-start;
   gap: 12px;
   width: 100%;
-  max-width: 460px;
+  max-width: 360px;
   text-align: left;
 }
 
@@ -229,4 +230,72 @@
   color: #b00020;
   font-weight: 700;
   line-height: 1.5;
+}
+
+.rules-section {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+  flex: 1 1 380px;
+  width: 100%;
+}
+
+.rule-card {
+  border: 1px solid #d9d9d9;
+  border-radius: 12px;
+  padding: 16px 18px;
+  background: #fafafa;
+  text-align: left;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.04);
+  height: 100%;
+}
+
+.rule-card-waiver {
+  border-color: #d32f2f;
+  background: #fff6f6;
+}
+
+.rule-heading {
+  font-weight: 700;
+  margin: 0 0 8px;
+}
+
+.rule-tag {
+  display: inline-block;
+  padding: 4px 10px;
+  border-radius: 999px;
+  background: #0f766e;
+  color: white;
+  font-size: 0.95rem;
+  font-weight: 700;
+  margin-bottom: 12px;
+}
+
+.rule-card-waiver .rule-tag {
+  background: #b00020;
+}
+
+.rule-card ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.rule-card li {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 10px;
+  border: 1px dashed #e5e5e5;
+  border-radius: 10px;
+  background: white;
+  font-weight: 600;
+}
+
+.rule-card li span {
+  color: #555;
+  font-weight: 500;
 }


### PR DESCRIPTION
## Summary
- add calculated current and next shot rule panels to the admin player modal
- style the modal layout to accommodate rule cards alongside the scoring controls

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69429d92929c832c9ded7a4eb27107e8)