### PR TITLE
Adjust shot modal controls and styling

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -355,14 +355,6 @@ const Modal: React.FC<ModalProps> = ({ name, isOpen, onClose, playerId }) => {
             <p>
               Shots Taken Today: <span>{shotsTakenToday !== null ? shotsTakenToday : '...'}</span>
             </p>
-            {shotsTakenToday === 3 && (
-              <p className="waiver-disclaimer">
-                <strong>
-                  You are logging your 4th shot, any additional shots today will be waiver attempts. For a waiver
-                  attempt you get only one die to roll, no practice shot, and you sacrifice your second attempt.
-                </strong>
-              </p>
-            )}
             <div className="points">
               <button className={points === 0 ? 'selected' : ''} onClick={() => setPoints(0)}>0</button>
               <button className={points === 1 ? 'selected' : ''} onClick={() => setPoints(1)}>1</button>

--- a/src/components/Modal/modal.css
+++ b/src/components/Modal/modal.css
@@ -220,9 +220,36 @@
   width: 100%;
 }
 
+.points button {
+  flex: 1;
+  padding: 20px 32px;
+  font-size: 1.25rem;
+  min-width: 96px;
+  min-height: 72px;
+}
+
+.actions button {
+  width: 100%;
+  padding: 20px 0;
+  font-size: 1.2rem;
+  font-weight: 700;
+  border-width: 2px;
+}
+
 .submit-button {
-  align-self: flex-start;
-  padding-inline: 32px;
+  align-self: center;
+  padding: 18px 40px;
+  background-color: #2e7d32;
+  color: #ffffff;
+  border: 2px solid #1b5e20;
+  font-size: 1.15rem;
+  font-weight: 700;
+  min-width: 180px;
+}
+
+.submit-button:hover {
+  background-color: #27642b;
+  color: #ffffff;
 }
 
 .waiver-disclaimer {


### PR DESCRIPTION
## Summary
- remove the waiver disclaimer text from the shot modal
- enlarge the point selection buttons and align the double button width with them
- center and restyle the submit button to be larger and green

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942a3512a9c832c965ee5716dc41d12)