### PR TITLE
Fix shot refund order and update submit button styling

### DIFF
--- a/src/components/AdjustShots.tsx
+++ b/src/components/AdjustShots.tsx
@@ -102,6 +102,11 @@ const AdjustShots: React.FC<AdjustShotsProps> = ({ isOpen }) => {
       return;
     }
 
+    // If the admin is giving shots back, remove the most recent shots from today
+    if (adjustment > 0 && playerToUpdate?.player_instance_id) {
+      await removeTodaysShots(playerToUpdate.player_instance_id, adjustment);
+    }
+
     // Update the player's shot count in the database
     const { error } = await supabase
       .from('player_instance')
@@ -111,11 +116,6 @@ const AdjustShots: React.FC<AdjustShotsProps> = ({ isOpen }) => {
     if (error) {
       console.error('Error updating shots left:', error);
       return;
-    }
-
-    // If the admin is giving shots back, remove the most recent shots from today
-    if (adjustment > 0 && playerToUpdate?.player_instance_id) {
-      await removeTodaysShots(playerToUpdate.player_instance_id, adjustment);
     }
   };
 

--- a/src/components/Modal/modal.css
+++ b/src/components/Modal/modal.css
@@ -89,6 +89,18 @@
   border-radius: 12px;
   min-width: 72px;
 }
+
+.submit-button {
+  background-color: #28a745;
+  border-color: #218838;
+  color: #ffffff;
+  font-weight: 600;
+}
+
+.submit-button:hover {
+  background-color: #218838;
+  border-color: #1e7e34;
+}
 .moneyball-indicator {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- restyle the modal submit button with a green treatment consistent with common web UI patterns
- adjust shot refund flow so shot deletions occur before updating player instances

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6942a7408aa8832c95c485b523129835)