### PR TITLE
Enhance start season modal layout and inline player controls

### DIFF
--- a/src/components/NextSeason/NextSeason.module.css
+++ b/src/components/NextSeason/NextSeason.module.css
@@ -17,17 +17,17 @@
 /* Main Modal */
 .modal {
   background: white;
-  padding: 20px;
-  border-radius: 8px;
-  width: 90%;
-  max-width: 600px;
+  padding: 24px;
+  border-radius: 12px;
+  width: 95%;
+  max-width: 1200px;
   box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
   overflow-y: auto;
-  max-height: calc(100vh - 64px);
+  max-height: calc(100vh - 48px);
   position: relative;
   display: flex;
   flex-direction: column;
-  gap: 10px;
+  gap: 16px;
 }
 
 /* Close Button */
@@ -75,7 +75,7 @@
 }
 
 .scrollableList {
-  max-height: 150px;
+  max-height: 220px;
   overflow-y: auto;
   padding-right: 10px;
   margin-bottom: 10px;
@@ -89,6 +89,13 @@
   background: #f0f0f0;
   margin-bottom: 5px;
   border-radius: 4px;
+  gap: 8px;
+}
+
+.itemActions {
+  display: flex;
+  gap: 8px;
+  align-items: center;
 }
 
 .editButton,
@@ -110,12 +117,11 @@
 .addButton {
   background-color: #4caf50;
   color: white;
-  padding: 10px;
+  padding: 10px 14px;
   border: none;
   border-radius: 4px;
   cursor: pointer;
   margin-top: 10px;
-  width: 100%;
 }
 
 .addButton:hover {
@@ -155,7 +161,7 @@
 .globalButton {
   background-color: #2196f3;
   color: white;
-  padding: 10px;
+  padding: 12px;
   border: none;
   border-radius: 4px;
   cursor: pointer;
@@ -172,6 +178,8 @@
   display: flex;
   flex-direction: column;
   gap: 10px;
+  max-height: 90vh;
+  overflow-y: auto;
 }
 
 /* Modal input fields */
@@ -226,20 +234,6 @@
   margin-right: 10px;
 }
 
-/* Scrollable lists in modal */
-.scrollableList {
-  max-height: 150px; /* Set a reasonable max height */
-  overflow-y: auto;  /* Enable vertical scroll */
-  padding-right: 10px; /* Extra padding for scroll bar spacing */
-}
-
-/* Ensure modal content doesn't overflow */
-.modalContent {
-  max-height: 90vh; /* Constrain modal height */
-  overflow-y: auto; /* Scroll inside the modal */
-  padding: 20px;
-}
-
 /* Team, Tier, and Player lists */
 .team,
 .tier,
@@ -248,4 +242,70 @@
   padding: 10px;
   margin: 5px 0;
   border-radius: 4px;
+}
+
+.modalGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 16px;
+}
+
+.sectionHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.dragHandle {
+  cursor: grab;
+  font-weight: bold;
+  color: #777;
+}
+
+.tierDetails {
+  flex: 1;
+}
+
+.playersTable {
+  width: 100%;
+  border: 1px solid #e0e0e0;
+  border-radius: 8px;
+  overflow: hidden;
+  background: #fafafa;
+}
+
+.playersHeader,
+.playersRow {
+  display: grid;
+  grid-template-columns: 1.2fr 1fr 1fr auto;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 14px;
+}
+
+.playersHeader {
+  background: #f5f5f5;
+  font-weight: 600;
+}
+
+.playersBody {
+  max-height: 320px;
+  overflow-y: auto;
+}
+
+.playersRow {
+  border-top: 1px solid #e0e0e0;
+}
+
+.playersRow select {
+  width: 100%;
+  padding: 8px;
+  border-radius: 6px;
+  border: 1px solid #ccc;
+  background: #fff;
+}
+
+.headerActions {
+  text-align: right;
 }

--- a/src/components/NextSeason/NextSeason.tsx
+++ b/src/components/NextSeason/NextSeason.tsx
@@ -37,6 +37,7 @@ const NextSeasonModal: React.FC<NextSeasonModalProps> = ({ isOpen, onClose, onSt
   const [selectedPlayer, setSelectedPlayer] = useState<any>(null);
   const [selectedTeam, setSelectedTeam] = useState<any>(null);
   const [selectedTier, setSelectedTier] = useState<any>(null);
+  const [draggedTierId, setDraggedTierId] = useState<number | null>(null);
    /**
    * Effect: Fetch data when the modal opens.
    * This includes teams, tiers, and players data, and sets up real-time subscriptions.
@@ -225,6 +226,62 @@ const NextSeasonModal: React.FC<NextSeasonModalProps> = ({ isOpen, onClose, onSt
 
   const handleShotCountChange = (change: number) => {
     setShotCount(shotCount + change);
+  };
+
+  const handleReorderTier = (targetTierId: number) => {
+    setTiers((prevTiers) => {
+      if (draggedTierId === null || draggedTierId === targetTierId) return prevTiers;
+
+      const updated = [...prevTiers];
+      const fromIndex = updated.findIndex((tier) => tier.tier_id === draggedTierId);
+      const toIndex = updated.findIndex((tier) => tier.tier_id === targetTierId);
+
+      if (fromIndex === -1 || toIndex === -1) return prevTiers;
+
+      const [movedTier] = updated.splice(fromIndex, 1);
+      updated.splice(toIndex, 0, movedTier);
+
+      return updated;
+    });
+  };
+
+  const handleUpdatePlayerFields = async (playerId: number, updates: Record<string, any>) => {
+    const { data, error } = await supabase
+      .from('players')
+      .update(updates)
+      .eq('player_id', playerId)
+      .select()
+      .maybeSingle();
+
+    if (error) {
+      console.error('Error updating player:', error);
+      return;
+    }
+
+    setPlayers((prevPlayers) =>
+      prevPlayers.map((player) =>
+        player.player_id === playerId
+          ? {
+              ...player,
+              ...updates,
+              ...(data ?? {}),
+            }
+          : player
+      )
+    );
+  };
+
+  const handlePlayerTeamChange = async (playerId: number, teamValue: string) => {
+    if (teamValue === 'free-agent') {
+      await handleUpdatePlayerFields(playerId, { team_id: null, is_free_agent: true });
+      return;
+    }
+
+    await handleUpdatePlayerFields(playerId, { team_id: Number(teamValue), is_free_agent: false });
+  };
+
+  const handlePlayerTierChange = async (playerId: number, tierValue: string) => {
+    await handleUpdatePlayerFields(playerId, { tier_id: Number(tierValue) });
   };
 
   const closeOutCurrentSeason = async (seasonId: number) => {
@@ -613,85 +670,142 @@ const NextSeasonModal: React.FC<NextSeasonModalProps> = ({ isOpen, onClose, onSt
           />
         </div>
 
-        {/* Teams Management Section */}
-        <div className={styles.listSection}>
-          <h3>Teams</h3>
-          <div className={styles.scrollableList}>
-            {teams.map((team) => (
-              <div key={team.team_id} className={styles.listItem}>
-                {team.team_name}
-                <button
-                  className={styles.editButton}
-                  onClick={() => handleOpenEditTeamModal(team)}
-                >
-                  Edit
-                </button>
-                <button
-                  className={styles.deleteButton}
-                  onClick={() => handleDeleteTeam(team.team_id)}
-                >
-                  X
-                </button>
-              </div>
-            ))}
+        <div className={styles.modalGrid}>
+          {/* Teams Management Section */}
+          <div className={styles.listSection}>
+            <div className={styles.sectionHeader}>
+              <h3>Teams</h3>
+              <button className={styles.addButton} onClick={handleAddTeam}>
+                Add Team
+              </button>
+            </div>
+            <div className={styles.scrollableList}>
+              {teams.map((team) => (
+                <div key={team.team_id} className={styles.listItem}>
+                  <span>{team.team_name}</span>
+                  <div className={styles.itemActions}>
+                    <button
+                      className={styles.editButton}
+                      onClick={() => handleOpenEditTeamModal(team)}
+                    >
+                      Edit
+                    </button>
+                    <button
+                      className={styles.deleteButton}
+                      onClick={() => handleDeleteTeam(team.team_id)}
+                    >
+                      X
+                    </button>
+                  </div>
+                </div>
+              ))}
+            </div>
           </div>
-          <button className={styles.addButton} onClick={handleAddTeam}>
-            Add Team
-          </button>
-        </div>
 
-        {/* Tiers Management Section */}
-        <div className={styles.listSection}>
-          <h3>Tiers</h3>
-          <div className={styles.scrollableList}>
-            {tiers.map((tier) => (
-              <div key={tier.tier_id} className={styles.listItem}>
-                {tier.tier_name} (Color: {tier.color})
-                <button
-                  className={styles.editButton}
-                  onClick={() => handleOpenEditTierModal(tier)}
+          {/* Tiers Management Section */}
+          <div className={styles.listSection}>
+            <div className={styles.sectionHeader}>
+              <h3>Tiers</h3>
+              <button className={styles.addButton} onClick={handleAddTier}>
+                Add Tier
+              </button>
+            </div>
+            <div className={styles.scrollableList}>
+              {tiers.map((tier) => (
+                <div
+                  key={tier.tier_id}
+                  className={styles.listItem}
+                  draggable
+                  onDragStart={() => setDraggedTierId(tier.tier_id)}
+                  onDragEnter={() => handleReorderTier(tier.tier_id)}
+                  onDragEnd={() => setDraggedTierId(null)}
                 >
-                  Edit
-                </button>
-                <button
-                  className={styles.deleteButton}
-                  onClick={() => handleDeleteTier(tier.tier_id)}
-                >
-                  X
-                </button>
-              </div>
-            ))}
+                  <span className={styles.dragHandle} aria-label="Reorder tier">
+                    ⋮⋮
+                  </span>
+                  <span className={styles.tierDetails}>
+                    {tier.tier_name} (Color: {tier.color})
+                  </span>
+                  <div className={styles.itemActions}>
+                    <button
+                      className={styles.editButton}
+                      onClick={() => handleOpenEditTierModal(tier)}
+                    >
+                      Edit
+                    </button>
+                    <button
+                      className={styles.deleteButton}
+                      onClick={() => handleDeleteTier(tier.tier_id)}
+                    >
+                      X
+                    </button>
+                  </div>
+                </div>
+              ))}
+            </div>
           </div>
-          <button className={styles.addButton} onClick={handleAddTier}>
-            Add Tier
-          </button>
         </div>
 
         {/* Players Management Section */}
         <div className={styles.listSection}>
-          <h3>Players</h3>
-          <div className={styles.scrollableList}>
-            {players.map((player) => (
-              <div key={player.player_id} className={styles.listItem}>
-                {player.name}
-                <button
-                  className={styles.editButton}
-                  onClick={() => handleOpenEditPlayerModal(player)}
-                >
-                  Edit
-                </button>
-                <button
-                  className={styles.deleteButton}
-                  onClick={() => handleDeletePlayer(player.player_id)}
-                >
-                  X
-                </button>
-              </div>
-            ))}
+          <div className={styles.sectionHeader}>
+            <h3>Players</h3>
+            <button className={styles.addButton} onClick={handleAddPlayer}>
+              Add Player
+            </button>
           </div>
-          <button className={styles.addButton} onClick={handleAddPlayer}>
-            Add Player
-          </button>
+          <div className={styles.playersTable}>
+            <div className={styles.playersHeader}>
+              <span>Name</span>
+              <span>Team</span>
+              <span>Tier</span>
+              <span className={styles.headerActions}>Actions</span>
+            </div>
+            <div className={styles.playersBody}>
+              {players.map((player) => (
+                <div key={player.player_id} className={styles.playersRow}>
+                  <span>{player.name}</span>
+                  <select
+                    value={player.is_free_agent ? 'free-agent' : player.team_id ?? 'free-agent'}
+                    onChange={(e) => handlePlayerTeamChange(player.player_id, e.target.value)}
+                    aria-label={`Change team for ${player.name}`}
+                  >
+                    <option value="free-agent">Free Agent</option>
+                    {teams.map((team) => (
+                      <option key={team.team_id} value={team.team_id}>
+                        {team.team_name}
+                      </option>
+                    ))}
+                  </select>
+                  <select
+                    value={player.tier_id}
+                    onChange={(e) => handlePlayerTierChange(player.player_id, e.target.value)}
+                    aria-label={`Change tier for ${player.name}`}
+                  >
+                    {tiers.map((tier) => (
+                      <option key={tier.tier_id} value={tier.tier_id}>
+                        {tier.tier_name}
+                      </option>
+                    ))}
+                  </select>
+                  <div className={styles.itemActions}>
+                    <button
+                      className={styles.editButton}
+                      onClick={() => handleOpenEditPlayerModal(player)}
+                    >
+                      Edit
+                    </button>
+                    <button
+                      className={styles.deleteButton}
+                      onClick={() => handleDeletePlayer(player.player_id)}
+                    >
+                      X
+                    </button>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
         </div>
 
         {/* Shot Count Adjustment Section */}


### PR DESCRIPTION
## Summary
- enlarge the Start New Season modal layout to better accommodate detailed configuration
- add drag-and-drop tier reordering and inline player team/tier selectors for quicker edits
- refresh styling for list sections and the player management table to match the expanded modal

## Testing
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69435e68a54c832cb0480e04eacde3e0)