### PR TITLE
Improve season start modal layout and responsiveness

### DIFF
--- a/src/components/NextSeason/NextSeason.module.css
+++ b/src/components/NextSeason/NextSeason.module.css
@@ -15,12 +15,11 @@
 }
 
 /* Main Modal */
-.modal {
+.modal { 
   background: white;
   padding: 24px;
   border-radius: 12px;
-  width: 95%;
-  max-width: 1200px;
+  width: min(1200px, 100% - 32px);
   box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
   overflow-y: auto;
   max-height: calc(100vh - 48px);
@@ -28,6 +27,19 @@
   display: flex;
   flex-direction: column;
   gap: 16px;
+}
+
+.centeredBackdrop {
+  align-items: center;
+}
+
+.confirmModal {
+  max-width: 640px;
+  width: min(640px, 100% - 32px);
+  padding: 28px;
+  gap: 20px;
+  border-radius: 16px;
+  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.18);
 }
 
 /* Close Button */
@@ -198,6 +210,46 @@
   display: flex;
   justify-content: space-between;
   gap: 10px;
+}
+
+.confirmHeader h3 {
+  margin-bottom: 8px;
+}
+
+.confirmHeader p {
+  color: #4b5563;
+  margin: 0;
+  line-height: 1.5;
+}
+
+@media (max-width: 900px) {
+  .modal {
+    padding: 16px;
+    gap: 12px;
+  }
+
+  .modalBackdrop {
+    padding: 16px 10px;
+  }
+
+  .modalGrid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .modalActions {
+    flex-direction: column;
+  }
+
+  .saveButton,
+  .cancelButton {
+    width: 100%;
+  }
+
+  .confirmModal {
+    padding: 20px;
+  }
 }
 
 .saveButton,

--- a/src/components/NextSeason/NextSeason.tsx
+++ b/src/components/NextSeason/NextSeason.tsx
@@ -1019,13 +1019,22 @@ const NextSeasonModal: React.FC<NextSeasonModalProps> = ({ isOpen, onClose, onSt
         )}
 
         {isConfirmationOpen && (
-          <div className={styles.modalBackdrop} aria-modal="true" role="dialog" tabIndex={-1}>
-            <div className={styles.modal}>
+          <div className={`${styles.modalBackdrop} ${styles.centeredBackdrop}`} aria-modal="true" role="dialog" tabIndex={-1}>
+            <div className={`${styles.modal} ${styles.confirmModal}`}>
               <div className={styles.modalContent}>
-                <h3>Confirm New Season Start</h3>
-                <p>Confirm New Season Start</p>
+                <div className={styles.confirmHeader}>
+                  <h3>Confirm New Season Start</h3>
+                  <p>
+                    Starting a new season will create a fresh schedule and reset player shot counts.
+                    You can review these settings again before proceeding.
+                  </p>
+                </div>
                 <div className={styles.modalActions}>
-                  <button onClick={() => setIsConfirmationOpen(false)} className={styles.cancelButton} disabled={isProcessing}>
+                  <button
+                    onClick={() => setIsConfirmationOpen(false)}
+                    className={styles.cancelButton}
+                    disabled={isProcessing}
+                  >
                     Cancel
                   </button>
                   <button onClick={handleConfirmStartSeason} className={styles.saveButton} disabled={isProcessing}>


### PR DESCRIPTION
## Summary
- enlarge and restyle the confirmation modal with clearer messaging
- adjust modal sizing and centering to improve readability and aesthetics
- add responsive spacing and stacking so season modals remain usable on smaller screens

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694367e1bf60832c965106e686a607a0)