### PR TITLE
Add official season toggle and exclude free agents from player stats

### DIFF
--- a/src/app/Stats/page.tsx
+++ b/src/app/Stats/page.tsx
@@ -18,6 +18,13 @@ type PlayerStats = {
   points_per_shot: number;
 };
 
+type PlayerRow = {
+  player_id: number;
+  name: string;
+  is_hidden: boolean;
+  is_free_agent: boolean;
+};
+
 type SortKey = keyof PlayerStats;
 
 const getSortableLastName = (name: string) => {
@@ -89,13 +96,15 @@ const StatsPage: React.FC = () => {
       // Step 1: Fetch player data (including hidden status)
       const { data: playersData, error: playersError } = await supabase
         .from('players')
-        .select('player_id, name, is_hidden');
+        .select('player_id, name, is_hidden, is_free_agent');
 
       if (playersError) throw playersError;
       if (!playersData) return;
 
       // Step 2: Filter out hidden players
-      const visiblePlayersData = playersData.filter((p) => !p.is_hidden);
+      const visiblePlayersData: PlayerRow[] = playersData.filter(
+        (p) => !p.is_hidden && !p.is_free_agent,
+      );
 
       // Step 3: Fetch additional stats from the `stats` table
       const { data: statsData, error: statsError } = await supabase
@@ -107,34 +116,39 @@ const StatsPage: React.FC = () => {
       // Step 4: Get active season details
       const { data: currentSeason, error: seasonError } = await supabase
         .from('seasons')
-        .select('season_id, shot_total')
+        .select('season_id, shot_total, is_official')
         .is('end_date', null) // Only fetch the active season
         .single();
 
       if (seasonError || !currentSeason) throw seasonError;
 
       const currentSeasonId = currentSeason.season_id; // Active season ID
-      const seasonShotTotal = currentSeason.shot_total; // Total shots for the season
+      const includeCurrentSeasonStats = Boolean(currentSeason.is_official);
+      const seasonShotTotal = includeCurrentSeasonStats ? currentSeason.shot_total : 0; // Total shots for the season
 
       // Step 5: Fetch current season player instances
-      const { data: currentSeasonData, error: instanceError } = await supabase
-        .from('player_instance')
-        .select('player_id, score, shots_left')
-        .eq('season_id', currentSeasonId);
+      const { data: currentSeasonData, error: instanceError } = includeCurrentSeasonStats
+        ? await supabase
+            .from('player_instance')
+            .select('player_id, score, shots_left')
+            .eq('season_id', currentSeasonId)
+        : { data: [], error: null };
 
       if (instanceError) throw instanceError;
 
       // Step 6: Combine data for visible players
       const combinedData = visiblePlayersData.map((player) => {
         const playerStats = statsData?.find((stat) => stat.player_id === player.player_id);
-        const currentInstance = currentSeasonData?.find(
-          (instance) => instance.player_id === player.player_id
-        );
-        const currentSeasonScore = currentInstance?.score || 0;
-        const shotsLeft = currentInstance?.shots_left || 0;
+        const currentInstance = includeCurrentSeasonStats
+          ? currentSeasonData?.find((instance) => instance.player_id === player.player_id)
+          : undefined;
+        const currentSeasonScore = includeCurrentSeasonStats ? currentInstance?.score || 0 : 0;
+        const shotsLeft = includeCurrentSeasonStats ? currentInstance?.shots_left || 0 : 0;
 
         // Calculate current season shots taken
-        const currentSeasonShots = Math.max(0, seasonShotTotal - shotsLeft);
+        const currentSeasonShots = includeCurrentSeasonStats
+          ? Math.max(0, seasonShotTotal - shotsLeft)
+          : 0;
 
         // Calculate total shots and total score
         const totalShots = (playerStats?.total_shots || 0) + currentSeasonShots;

--- a/src/components/NextSeason/NextSeason.module.css
+++ b/src/components/NextSeason/NextSeason.module.css
@@ -81,6 +81,18 @@
   font-size: 1em;
 }
 
+.checkboxRow {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.helperText {
+  color: #555;
+  font-size: 0.9em;
+  margin: 6px 0 0 0;
+}
+
 /* Scrollable List */
 .listSection {
   margin-bottom: 20px;

--- a/src/components/NextSeason/NextSeason.tsx
+++ b/src/components/NextSeason/NextSeason.tsx
@@ -30,6 +30,7 @@ const NextSeasonModal: React.FC<NextSeasonModalProps> = ({ isOpen, onClose, onSt
   const [isFreeAgent, setIsFreeAgent] = useState<boolean>(false); // Indicates if the player is a free agent
   const [seasonName, setSeasonName] = useState<string>(''); // Name of the upcoming season
   const [seasonRules, setSeasonRules] = useState<string>(''); // Rules for the new season
+  const [isOfficialSeason, setIsOfficialSeason] = useState<boolean>(true); // Track whether the season should be recorded historically
   const [isConfirmationOpen, setIsConfirmationOpen] = useState<boolean>(false);
   const [isProcessing, setIsProcessing] = useState<boolean>(false);
 
@@ -49,6 +50,8 @@ const NextSeasonModal: React.FC<NextSeasonModalProps> = ({ isOpen, onClose, onSt
    */
   useEffect(() => {
     if (!isOpen) return;
+
+    setIsOfficialSeason(true);
 
     // Fetch teams from the database
     const fetchTeams = async () => {
@@ -282,7 +285,7 @@ const NextSeasonModal: React.FC<NextSeasonModalProps> = ({ isOpen, onClose, onSt
     await handleUpdatePlayerFields(playerId, { tier_id: tierValue });
   };
 
-  const closeOutCurrentSeason = async (seasonId: number) => {
+  const closeOutCurrentSeason = async (seasonId: number, isOfficialSeason: boolean) => {
     console.log('Closing out season ID:', seasonId);
   
     // Retrieve the season shot total for calculating shots taken
@@ -295,6 +298,29 @@ const NextSeasonModal: React.FC<NextSeasonModalProps> = ({ isOpen, onClose, onSt
     if (seasonError) handleError(seasonError, 'Failed to retrieve current season');
     if (!currentSeason) handleError(null, 'Current season data is null');
     const seasonShotTotal = currentSeason ? currentSeason.shot_total || 0 : 0;
+
+    if (!isOfficialSeason) {
+      const currentDate = new Date().toISOString();
+      const { error: closeSeasonError } = await supabase
+        .from('seasons')
+        .update({ end_date: currentDate })
+        .eq('season_id', seasonId);
+
+      if (closeSeasonError) handleError(closeSeasonError, 'Failed to close the current season');
+      return;
+    }
+
+    const { data: playerRecords, error: playersError } = await supabase
+      .from('players')
+      .select('player_id, is_free_agent');
+
+    if (playersError) handleError(playersError, 'Failed to retrieve player records');
+
+    const eligiblePlayerIds = new Set(
+      (playerRecords || [])
+        .filter((player) => !player.is_free_agent)
+        .map((player) => player.player_id),
+    );
   
     // Step 1: Calculate team and player stats for the current season
     // Find the team with the highest score
@@ -411,7 +437,12 @@ const NextSeasonModal: React.FC<NextSeasonModalProps> = ({ isOpen, onClose, onSt
     }
     if (!playerInstances) return;
 
-    for (const instance of playerInstances) {
+    const filteredPlayerInstances =
+      eligiblePlayerIds.size > 0
+        ? playerInstances.filter((instance) => eligiblePlayerIds.has(instance.player_id))
+        : playerInstances;
+
+    for (const instance of filteredPlayerInstances) {
       const playerId = instance.player_id;
       if (!statsByPlayer[playerId]) {
         statsByPlayer[playerId] = {
@@ -430,7 +461,12 @@ const NextSeasonModal: React.FC<NextSeasonModalProps> = ({ isOpen, onClose, onSt
   
     // Update player stats
     if (!playerStatsList) return;
-    for (const playerStat of playerStatsList) {
+    const eligiblePlayerStatsList =
+      eligiblePlayerIds.size > 0
+        ? playerStatsList.filter((player) => eligiblePlayerIds.has(player.player_id))
+        : playerStatsList;
+
+    for (const playerStat of eligiblePlayerStatsList) {
       const playerId = playerStat.player_id;
       const stats = statsByPlayer[playerId];
   
@@ -566,6 +602,7 @@ const NextSeasonModal: React.FC<NextSeasonModalProps> = ({ isOpen, onClose, onSt
         end_date: null,
         shot_total: shotCount,
         rules: seasonRules || 'Default Rules',
+        is_official: isOfficialSeason,
       })
       .select();
   
@@ -589,7 +626,7 @@ const NextSeasonModal: React.FC<NextSeasonModalProps> = ({ isOpen, onClose, onSt
       // Fetch the current active season
       const { data: currentSeason, error: currentSeasonError } = await supabase
         .from('seasons')
-        .select('season_id, end_date')
+        .select('season_id, end_date, is_official')
         .order('start_date', { ascending: false })
         .limit(1)
         .maybeSingle();
@@ -601,7 +638,7 @@ const NextSeasonModal: React.FC<NextSeasonModalProps> = ({ isOpen, onClose, onSt
       const seasonId = currentSeason.season_id;
 
       // Step 1: Close out the current season
-      await closeOutCurrentSeason(seasonId);
+      await closeOutCurrentSeason(seasonId, Boolean(currentSeason.is_official));
 
       // Step 2: Apply roster updates
       const newTeamIdMap = new Map<string, number>();
@@ -819,6 +856,22 @@ const NextSeasonModal: React.FC<NextSeasonModalProps> = ({ isOpen, onClose, onSt
             onChange={(e) => setSeasonRules(e.target.value)}
             placeholder="Enter season rules"
           />
+        </div>
+
+        <div className={styles.formSection}>
+          <label htmlFor="officialSeason">Official Season</label>
+          <div className={styles.checkboxRow}>
+            <input
+              id="officialSeason"
+              type="checkbox"
+              checked={isOfficialSeason}
+              onChange={(e) => setIsOfficialSeason(e.target.checked)}
+            />
+            <span>Record stats to Player Stats</span>
+          </div>
+          <p className={styles.helperText}>
+            Leave unchecked for draft seasons; their stats will be cleared when the next season starts.
+          </p>
         </div>
 
         <div className={styles.modalGrid}>


### PR DESCRIPTION
## Summary
- add an official season toggle in the start new season flow and persist the flag when creating seasons
- skip recording draft season and free-agent data into historical stats when closing a season
- filter the Player Stats page to only include official-season, non-free-agent players

## Testing
- npm run lint


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69436c26e068832c8ca9e0b6918232ee)