### PR TITLE
Rename start season sidebar option

### DIFF
--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -14,7 +14,7 @@ const Sidebar: React.FC<SidebarProps> = ({ isOpen, onClose, onCurrentSeasonClick
       <button className={styles.closeBtn} onClick={onClose}>X</button>
       <div className={styles.sidebarContent}>
         <div className={styles.option} onClick={onCurrentSeasonClick}>Current Season</div>
-        <div className={styles.option} onClick={onStartSeasonClick}>Start Season</div>
+        <div className={styles.option} onClick={onStartSeasonClick}>New Season Setup</div>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- rename the admin sidebar "Start Season" option to "New Season Setup"

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69436e9d9818832cab4bd0e460e9b678)