### PR TITLE
Replace official season checkbox with toggle

### DIFF
--- a/src/components/NextSeason/NextSeason.module.css
+++ b/src/components/NextSeason/NextSeason.module.css
@@ -81,10 +81,68 @@
   font-size: 1em;
 }
 
-.checkboxRow {
+.toggleRow {
   display: flex;
   align-items: center;
-  gap: 10px;
+  gap: 12px;
+}
+
+.toggleControl {
+  position: relative;
+  width: 48px;
+  height: 28px;
+  display: inline-flex;
+  align-items: center;
+  cursor: pointer;
+}
+
+.toggleInput {
+  position: absolute;
+  opacity: 0;
+  width: 0;
+  height: 0;
+}
+
+.toggleTrack {
+  position: relative;
+  width: 100%;
+  height: 100%;
+  background-color: #dcdcdc;
+  border-radius: 999px;
+  box-shadow: inset 0 0 0 1px #c0c0c0;
+  transition: background-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.toggleTrack::after {
+  content: "";
+  position: absolute;
+  top: 3px;
+  left: 4px;
+  width: 22px;
+  height: 22px;
+  background: #ffffff;
+  border-radius: 50%;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.15);
+  transition: transform 0.2s ease;
+  border: 1px solid #c0c0c0;
+}
+
+.toggleInput:focus-visible + .toggleTrack {
+  box-shadow: 0 0 0 3px rgba(76, 175, 80, 0.25), inset 0 0 0 1px #8bc34a;
+}
+
+.toggleInput:checked + .toggleTrack {
+  background-color: #4caf50;
+  box-shadow: inset 0 0 0 1px #4caf50;
+}
+
+.toggleInput:checked + .toggleTrack::after {
+  transform: translateX(18px);
+}
+
+.toggleText {
+  font-size: 1em;
+  color: #333;
 }
 
 .helperText {

--- a/src/components/NextSeason/NextSeason.tsx
+++ b/src/components/NextSeason/NextSeason.tsx
@@ -860,14 +860,19 @@ const NextSeasonModal: React.FC<NextSeasonModalProps> = ({ isOpen, onClose, onSt
 
         <div className={styles.formSection}>
           <label htmlFor="officialSeason">Official Season</label>
-          <div className={styles.checkboxRow}>
-            <input
-              id="officialSeason"
-              type="checkbox"
-              checked={isOfficialSeason}
-              onChange={(e) => setIsOfficialSeason(e.target.checked)}
-            />
-            <span>Record stats to Player Stats</span>
+          <div className={styles.toggleRow}>
+            <label className={styles.toggleControl} htmlFor="officialSeason">
+              <input
+                id="officialSeason"
+                aria-label="Official Season"
+                className={styles.toggleInput}
+                type="checkbox"
+                checked={isOfficialSeason}
+                onChange={(e) => setIsOfficialSeason(e.target.checked)}
+              />
+              <span className={styles.toggleTrack} aria-hidden="true" />
+            </label>
+            <span className={styles.toggleText}>Record stats to Player Stats</span>
           </div>
           <p className={styles.helperText}>
             Leave unchecked for draft seasons; their stats will be cleared when the next season starts.


### PR DESCRIPTION
## Summary
- replace the official season checkbox with a toggle-style control
- add styling for the new toggle to match the page sizing and provide focus/checked states
- keep the existing helper text while aligning the toggle label with the control

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6943705aac7c832cb0ffe36bdee70a1b)