### PR TITLE
Handle season transitions without active season

### DIFF
--- a/src/app/Standings/page.tsx
+++ b/src/app/Standings/page.tsx
@@ -139,9 +139,10 @@ const updateTeamScores = async () => {
       .from('seasons')
       .select('season_id')
       .is('end_date', null)
-      .single();
+      .maybeSingle();
 
-    if (seasonError || !activeSeason) throw seasonError;
+    if (seasonError) throw seasonError;
+    if (!activeSeason) return;
     const activeSeasonId = activeSeason.season_id;
 
     // Fetch all teams
@@ -249,10 +250,15 @@ const StandingsPage: React.FC = () => {
         .from('seasons')
         .select('season_id, season_name, shot_total, rules')
         .is('end_date', null)
-        .single();
-  
-      if (seasonError || !activeSeason) throw seasonError;
-  
+        .maybeSingle();
+
+      if (seasonError) throw seasonError;
+      if (!activeSeason) {
+        setSeason({ season_id: -1, season_name: 'No Active Season', shot_total: 0, rules: '' });
+        setTeams([]);
+        return;
+      }
+
       const activeSeasonId = activeSeason.season_id;
       setSeason(activeSeason);
         // Fetch teams

--- a/src/components/NextSeason/NextSeason.tsx
+++ b/src/components/NextSeason/NextSeason.tsx
@@ -616,14 +616,14 @@ const NextSeasonModal: React.FC<NextSeasonModalProps> = ({ isOpen, onClose, onSt
         .maybeSingle();
 
       if (currentSeasonError) handleError(currentSeasonError, 'Failed to retrieve current season');
-      if (!currentSeason) throw new Error('Current season data is null');
-      if (currentSeason.end_date) throw new Error('No active season to close out.');
 
-      const seasonId = currentSeason.season_id;
+      if (currentSeason && !currentSeason.end_date) {
+        const seasonId = currentSeason.season_id;
 
-      // Step 1: Close out the current season
-      await closeOutCurrentSeason(seasonId, Boolean(currentSeason.is_official));
-      closedSeasonId = seasonId;
+        // Step 1: Close out the current season
+        await closeOutCurrentSeason(seasonId, Boolean(currentSeason.is_official));
+        closedSeasonId = seasonId;
+      }
 
       // Step 2: Apply roster updates
       const newTeamIdMap = new Map<string, number>();


### PR DESCRIPTION
## Summary
- allow the standings page to handle situations with no active season instead of failing to load
- skip recalculating team scores when there is no active season
- let admins start a new season even if no current season is active to close

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69437f81a5b0832ca4d677a22b57304d)