### PR TITLE
Remove bottom summary bar from Standings and keep player names on one line

### DIFF
--- a/src/app/Standings/StandingsPage.module.css
+++ b/src/app/Standings/StandingsPage.module.css
@@ -81,6 +81,15 @@
   display: inline-flex; /* Ensures the circle and name stay on the same line */
   align-items: center;  /* Vertically aligns the circle and name */
   flex-basis: 33%;
+  gap: 6px;
+  white-space: nowrap;
+  overflow: hidden;
+}
+
+.playerNameText {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .shotsLeft,
 .totalPoints,
@@ -227,6 +236,7 @@
   display: flex;
   justify-content: flex-start;
   align-items: center;
+  min-width: 0;
 }
 
 .colorCircle {
@@ -251,38 +261,6 @@
   font-size: 1.5rem;
   padding: 10px 0;
   border-bottom: 1px solid #ddd;
-}
-
-
-/* Summary card */
-.summary {
-  /* display: flex;
-  flex-direction: column; */
-  border: 1px solid #ddd;
-  padding: 10px;
-  margin-top: 10px;
-  border-radius: 10px;
-  background-color: #fafafa;
-  box-sizing: border-box;
-  width: 100%;
-}
-
-/* Summary Row Styling */
-.summaryHeader {
-  display: grid;
-  grid-template-columns: 1fr 1fr 1fr; /* Add columns as this grows */
-  justify-items: center;
-  font-size: 1.3rem;
-  font-weight: bold;
-  text-decoration-line: underline;
-}
-
-.totalStats {
-  display: grid;
-  grid-template-columns: 1fr 1fr 1fr; /* Add columns as this grows */
-  justify-items: center;
-  font-size: 1.3rem;
-  font-weight: bold;
 }
 
 

--- a/src/app/Standings/page.tsx
+++ b/src/app/Standings/page.tsx
@@ -4,11 +4,7 @@ import styles from './StandingsPage.module.css'; // Updated path for combined st
 import { supabase } from '@/supabaseClient';
 import { FaFireFlameCurved } from "react-icons/fa6";
 import { FaSnowflake } from "react-icons/fa6"; 
-import {eachDayOfInterval, startOfMonth, endOfMonth, isWeekend} from 'date-fns'
-import { usePathname, useRouter } from 'next/navigation';
-import { Howl } from 'howler';
-
-import { stat } from 'fs';
+import { useRouter } from 'next/navigation';
 
 import Header from '@/components/Header';
 
@@ -199,20 +195,6 @@ const updateTeamScores = async () => {
   }
 };
 
-//function to calculate the waiver waterline based on the number of valid shooting days in the month
-const calculateWaiverWaterline = (date: Date, shotTotal: number): number =>{
-  //get an array of dates containing the days left in the month
-  const daysInMonth = eachDayOfInterval({
-    start: date,
-    end: endOfMonth(date),
-  });
-
-  // get the number of business days remaining in the month. TODO: turn shotsPerDay and business day toggle into settings in a settings page
-  const remainingBusinessDays =  daysInMonth.filter(day => !isWeekend(day)).length;
-  const shotsPerDay = 4;
-  return remainingBusinessDays*shotsPerDay > shotTotal? shotTotal: remainingBusinessDays*shotsPerDay;
-}
-
 const StandingsPage: React.FC = () => {
  // State variables
  const [teams, setTeams] = useState<TeamWithPlayers[]>([]); // Stores the list of teams and their players
@@ -223,7 +205,6 @@ const StandingsPage: React.FC = () => {
   shot_total: -1,
   rules: ''
  }); // Current season info
- const [waiverWaterline, setWaiverWaterline] = useState<number>(0); // Remaining shooting days in season
  const router = useRouter(); // Router for navigation
 
   /**
@@ -504,40 +485,6 @@ const StandingsPage: React.FC = () => {
       };
   }, [userView ]);
 
-/**
- * Set up timers for updating the waiver waterline every day
- */
-  useEffect(() => {
-    const now = new Date();
-const midnight = new Date(
-  now.getFullYear(),
-  now.getMonth(),
-  now.getDate() + 1,
-  0, 0, 0, 0
-);
-const timeUntilMidnight = midnight.getTime() - now.getTime(); 
-
-
-    const timeout = setTimeout(() => {
-      //calculate waterline at the next midnight from mount
-      setWaiverWaterline(calculateWaiverWaterline(new Date(), season.shot_total));
-      console.log("Setting waterline on first midnight to : ", calculateWaiverWaterline(new Date(), season.shot_total));
-      // calculate waterline every day at midnight after first midnight from mount
-      const interval = setInterval(() => {
-        setWaiverWaterline(calculateWaiverWaterline(new Date(), season.shot_total));
-        console.log("Setting waterline every midnight to : ", calculateWaiverWaterline(new Date(), season.shot_total));
-      }, 24 * 60 * 60 * 1000); //every 24 hours
-
-      return () => clearInterval(interval);
-    }, timeUntilMidnight);
-
-    //calculate waterline on mount
-    setWaiverWaterline(calculateWaiverWaterline(new Date(), season.shot_total));
-    console.log("Setting waterline on mount to : ", calculateWaiverWaterline(new Date(), season.shot_total));
-
-    return () => clearTimeout(timeout);
-  }, [season.shot_total]);
-
  return (
   <div className={styles.userContainer}>
     <Header></Header>
@@ -583,7 +530,7 @@ const timeUntilMidnight = midnight.getTime() - now.getTime();
                           className={styles.colorCircle}
                           style={{ backgroundColor: player.tier_color }}
                         />
-                        <span>{player.name}</span>
+                        <span className={styles.playerNameText}>{player.name}</span>
                         {player.name === 'A. Begy' && (
                           <span className={styles.crownIcon}>👑</span>
                         )}
@@ -610,18 +557,6 @@ const timeUntilMidnight = midnight.getTime() - now.getTime();
               ))}
               </div>
             ))}
-          </div>
-          <div className={styles.summary}>
-            <div className={styles.summaryHeader}>
-              <span>Total Shots Remaining</span>
-              <span>Total Score</span>
-              <span>Waiver Waterline</span>
-            </div>
-            <div className={styles.totalStats}>
-              <span>{teams.reduce((a, index) => a + index.total_shots, 0)}</span>
-              <span>{teams.reduce((a, index) => a + index.team_score, 0)}</span>
-              <span>{waiverWaterline}</span>
-            </div>
           </div>
         </div>
     </main>


### PR DESCRIPTION
### Motivation

- Remove the bottom summary bar (Total Shots Remaining / Total Score / Waiver Waterline) from the Standings page because those stats are no longer needed.
- Prevent player names from wrapping to a second line at the TV zoom level so the standings look cleaner.
- Remove the waiver waterline calculation and related state/effects since the summary UI that used it was removed.

### Description

- Removed the summary section and all related waiver waterline logic from `src/app/Standings/page.tsx`:
  - Deleted the `calculateWaiverWaterline` helper, `waiverWaterline` state, and the effect that updated it daily.
  - Removed the JSX block that rendered the summary card at the bottom of the Standings page.
- Kept player name and icon layout on a single line by adding truncation rules in `src/app/Standings/StandingsPage.module.css`:
  - `.playerName` now uses `white-space: nowrap` and `overflow: hidden`.
  - Added `.playerNameText` to apply `text-overflow: ellipsis` so long names truncate with an ellipsis.
  - Ensured `.playerNameColumn` uses `min-width: 0` so the ellipsis works properly in flex/grid contexts.
- Updated the player name element in `src/app/Standings/page.tsx` to use the new `.playerNameText` class.
- Removed a few no-longer-used imports from the top of the Standings page (unused date-fns helpers / extras) to keep imports tidy.

Files changed:
- `src/app/Standings/page.tsx` — removed summary UI & waiver logic; updated player name span class; cleaned imports
- `src/app/Standings/StandingsPage.module.css` — added truncation styles; removed summary CSS rules

### Testing

- Started the dev server with `npm run dev`. Next compiled the app and the Standings page; build logged a Google Fonts fetch error and used a fallback font (non-blocking), and the Standings page compiled successfully.
- Performed a quick HTTP check: `curl -I http://127.0.0.1:3000/Standings` returned `200 OK` for the page.
- Attempted an automated Playwright screenshot of `/Standings`, but Playwright failed to connect in this environment (connection refused on some attempts). The app did compile and serve during the run, but the screenshot step did not succeed.

If you want, I can:
- Re-add a lightweight summary elsewhere or make the summary toggleable in settings.
- Adjust the truncation behaviour (e.g., show a tooltip on hover with full name).
- Re-run visual verification / produce a screenshot in an environment with Playwright access.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694556a265d0832cb7cfe2adbdbea183)