### PR TITLE
Standings: show full player names and shorten headers (Score, SL)

### DIFF
--- a/src/app/Standings/StandingsPage.module.css
+++ b/src/app/Standings/StandingsPage.module.css
@@ -83,12 +83,10 @@
   flex-basis: 33%;
   gap: 6px;
   white-space: nowrap;
-  overflow: hidden;
+  overflow: visible;
 }
 
 .playerNameText {
-  overflow: hidden;
-  text-overflow: ellipsis;
   white-space: nowrap;
 }
 .shotsLeft,

--- a/src/app/Standings/page.tsx
+++ b/src/app/Standings/page.tsx
@@ -516,8 +516,8 @@ const StandingsPage: React.FC = () => {
                 {/* Table Headers */}
                 <div className={styles.row}>
                   <span className={styles.columnHeader}>Name</span>
-                  <span className={styles.columnHeader}>Total Score</span>
-                  <span className={styles.columnHeader}>Shots Left</span>
+                  <span className={styles.columnHeader}>Score</span>
+                  <span className={styles.columnHeader}>SL</span>
                   <span className={styles.columnHeader}>PPS</span>
                 </div>
                 {team.players.map((player, playerIndex) => (


### PR DESCRIPTION
### Motivation
- Player names were being truncated/ellipsized on the Standings page and could be hard to read. The UI should display the whole name on a single line without wrapping.
- The player table headers should be shortened in the player section for clarity: `Score` instead of `Total Score`, and `SL` instead of `Shots Left`.

### Description
- CSS: updated `src/app/Standings/StandingsPage.module.css`
  - `.playerName`: changed `overflow` from `hidden` to `visible` so full names are shown and don't wrap to a second line.
  - `.playerNameText`: removed `overflow: hidden` and `text-overflow: ellipsis` so names are not truncated.
- UI: updated `src/app/Standings/page.tsx` to rename the player table headers from `Total Score` / `Shots Left` to `Score` / `SL`.

### Testing
- Started the dev server with `npm run dev`; Next compiled the Standings route (server returned 200 for `/Standings`).
- Attempted an automated screenshot with Playwright to validate the layout, but the Playwright run failed to connect (`ERR_CONNECTION_REFUSED`) in this environment. Additionally Next logged a Google Fonts fetch warning (fallback font used) during compilation.
- Files changed and committed: `src/app/Standings/StandingsPage.module.css`, `src/app/Standings/page.tsx`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69455a84dd58832c9e449862b12d7059)