### PR TITLE
Revamp current season controls modal — two-tab adjustments + shot-history undo

### DIFF
--- a/src/components/CurrentSeason/CurrentSeasonModal.module.css
+++ b/src/components/CurrentSeason/CurrentSeasonModal.module.css
@@ -1,7 +1,6 @@
 .currentSeasonModal {
   position: fixed;
-  top: 0;
-  left: 0;
+  inset: 0;
   width: 100%;
   height: 100%;
   background: rgba(0, 0, 0, 0.5);
@@ -9,7 +8,7 @@
   justify-content: center;
   align-items: flex-start;
   overflow-y: auto;
-  padding: 20px 12px;
+  padding: 24px 16px;
   opacity: 0;
   pointer-events: none;
   transition: opacity 0.3s ease;
@@ -24,15 +23,14 @@
 .modalContent {
   background: #fff;
   padding: 20px;
-  border-radius: 8px;
-  width: 80%;
-  max-width: 900px;
+  border-radius: 12px;
+  width: min(1100px, 96vw);
   display: flex;
   flex-direction: column;
   position: relative;
   max-height: calc(100vh - 64px);
   overflow: hidden;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.18);
 }
 
 .headerRow {
@@ -40,11 +38,11 @@
   justify-content: space-between;
   align-items: center;
   gap: 16px;
-  margin-bottom: 16px;
+  margin-bottom: 12px;
 }
 
 .title {
-  font-size: 1.5rem;
+  font-size: 1.6rem;
   margin: 0 0 4px;
 }
 
@@ -53,111 +51,169 @@
   color: #4b5563;
 }
 
-.tableWrapper {
-  margin: 12px 0 16px;
-  border: 1px solid #e5e7eb;
-  border-radius: 12px;
-  background: #f9fafb;
-}
-
-.tableHeader {
+.tabBar {
   display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
-  gap: 12px;
-  padding: 12px 16px 0;
-}
-
-.tableTitle {
-  margin: 0;
-  font-weight: 600;
-  color: #111827;
-}
-
-.tableHelp {
-  margin: 4px 0 0;
-  color: #4b5563;
-  font-size: 0.95rem;
-}
-
-.quickSelect {
-  display: flex;
-  align-items: center;
   gap: 8px;
+  border-bottom: 1px solid #e5e7eb;
+  margin-bottom: 12px;
+  flex-wrap: wrap;
+}
+
+.tabButton {
+  border: none;
+  background: transparent;
+  padding: 10px 14px;
   font-weight: 600;
-}
-
-.select {
-  padding: 8px;
-  border-radius: 8px;
-  border: 1px solid #d1d5db;
-  background: #fff;
-  min-width: 140px;
-}
-
-.controlsTable {
-  width: 100%;
-  border-collapse: collapse;
-  margin-top: 8px;
-}
-
-.controlsTable th,
-.controlsTable td {
-  padding: 12px 16px;
-  text-align: left;
-  border-top: 1px solid #e5e7eb;
-}
-
-.controlsTable th {
-  background: #f3f4f6;
-  font-weight: 700;
-  color: #111827;
-}
-
-.controlsTable tbody tr:hover {
-  background: #f8fafc;
-}
-
-.inlineActions {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.inlineEditBtn {
-  padding: 8px 12px;
-  border-radius: 8px;
-  border: 1px solid #2563eb;
-  background: #2563eb;
-  color: white;
+  border-radius: 8px 8px 0 0;
   cursor: pointer;
-  transition: background 0.2s ease, border-color 0.2s ease;
+  color: #4b5563;
 }
 
-.inlineEditBtn:hover {
-  background: #1d4ed8;
-  border-color: #1d4ed8;
+.tabButton:hover {
+  background: #f3f4f6;
 }
 
-.activeRow {
+.activeTab {
+  color: #111827;
   background: #eef2ff;
+  border-bottom: 2px solid #2563eb;
 }
 
 .contentWrapper {
   flex: 1;
-  border: 1px dashed #e5e7eb;
+  border: 1px solid #e5e7eb;
   border-radius: 12px;
-  padding: 16px;
+  padding: 12px;
   background: #f9fafb;
+  overflow: hidden;
 }
 
 .content {
-  flex: 1;
-  padding: 4px;
-  overflow-y: auto;
+  height: 100%;
+  overflow: hidden;
+}
+
+.tabPanel {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  height: 100%;
+}
+
+.panelHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.panelHeader h3 {
+  margin: 0 0 4px;
+}
+
+.panelHeader p {
+  margin: 0;
+  color: #4b5563;
+}
+
+.tableScroll {
+  overflow: auto;
   background: white;
   border-radius: 12px;
   border: 1px solid #e5e7eb;
+  flex: 1;
+}
+
+.dataTable {
+  width: 100%;
+  border-collapse: collapse;
+  min-width: 620px;
+}
+
+.dataTable th,
+.dataTable td {
+  padding: 12px 14px;
+  text-align: left;
+  border-bottom: 1px solid #e5e7eb;
+  vertical-align: top;
+}
+
+.dataTable th {
+  background: #f3f4f6;
+  font-weight: 700;
+  color: #111827;
+  position: sticky;
+  top: 0;
+  z-index: 1;
+}
+
+.dataTable tbody tr:hover {
+  background: #f8fafc;
+}
+
+.emptyState {
+  text-align: center;
+  color: #6b7280;
+  padding: 24px 12px;
+}
+
+.playerCell {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.playerCell input {
+  width: 100%;
+}
+
+.numericField {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.numericField input {
+  width: 100%;
+}
+
+.pendingNote {
+  font-size: 0.8rem;
+  color: #2563eb;
+}
+
+.newRow {
+  background: #ecfeff;
+}
+
+.undoRow {
+  background: #fef3c7;
+}
+
+.pendingBadge {
+  background: #eef2ff;
+  color: #1d4ed8;
+  padding: 6px 10px;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.linkButton {
+  border: none;
+  background: none;
+  color: #dc2626;
+  font-size: 0.85rem;
+  text-align: left;
+  padding: 0;
+  cursor: pointer;
+}
+
+.loadingState {
+  padding: 24px;
+  text-align: center;
+  color: #6b7280;
 }
 
 .topCloseBtn {
@@ -214,10 +270,10 @@
   background-color: #e5e7eb;
   color: #111827;
   border: 1px solid #d1d5db;
-  padding: 10px 18px;
+  padding: 8px 14px;
   border-radius: 8px;
   cursor: pointer;
-  font-size: 1rem;
+  font-size: 0.95rem;
   transition: background-color 0.2s ease, color 0.2s ease;
 }
 
@@ -253,4 +309,25 @@
   justify-content: flex-end;
   gap: 12px;
   flex-wrap: wrap;
+}
+
+@media (max-width: 768px) {
+  .modalContent {
+    padding: 16px;
+  }
+
+  .dataTable {
+    min-width: 560px;
+  }
+}
+
+@media (max-width: 560px) {
+  .dataTable {
+    min-width: 480px;
+  }
+
+  .tabButton {
+    width: 100%;
+    text-align: left;
+  }
 }

--- a/src/components/CurrentSeason/CurrentSeasonModal.tsx
+++ b/src/components/CurrentSeason/CurrentSeasonModal.tsx
@@ -1,38 +1,167 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import styles from './CurrentSeasonModal.module.css';
-import AdjustShots from '../AdjustShots';
-import AdjustTeams from '../AdjustTeams';
-import AdjustScores from '../AdjustScores';
-import AdjustTiers from '../AdjustTier';
-import AddPlayers from '../AddPlayers';
-import AdjustRules from '../AdjustRules';
+import { supabase } from '@/supabaseClient';
 
-// Type definition for the component's props
 interface CurrentSeasonModalProps {
-  isOpen: boolean; // Determines whether the modal is open
-  onClose: () => void; // Function to handle closing the modal
+  isOpen: boolean;
+  onClose: () => void;
 }
 
-/**
- * CurrentSeasonModal Component
- *
- * This component displays a modal with inline table controls to manage and adjust
- * various aspects of the current season, such as shots, teams, scores, tiers,
- * players, and rules.
- *
- * Props:
- * - `isOpen` (boolean): Controls whether the modal is visible.
- * - `onClose` (function): Callback function to close the modal.
- */
+type TabKey = 'adjustments' | 'history';
+
+interface TeamOption {
+  team_id: number;
+  team_name: string;
+}
+
+interface TierOption {
+  tier_id: number;
+  tier_name: string;
+}
+
+interface PlayerAdjustmentRow {
+  key: string;
+  playerInstanceId?: number;
+  playerId?: number;
+  name: string;
+  shotsLeft: number;
+  score: number;
+  teamId: number | null;
+  tierId: number | null;
+  isNew: boolean;
+}
+
+interface ShotHistoryRow {
+  shotId: number;
+  instanceId: number;
+  playerName: string;
+  shotNumber: number;
+  points: number;
+  shotDate: string;
+}
+
 const CurrentSeasonModal: React.FC<CurrentSeasonModalProps> = ({ isOpen, onClose }) => {
-  const [activeTab, setActiveTab] = useState('Adjust Shots');
+  const [activeTab, setActiveTab] = useState<TabKey>('adjustments');
   const [isSubmitConfirmationOpen, setIsSubmitConfirmationOpen] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [seasonId, setSeasonId] = useState<number | null>(null);
+  const [players, setPlayers] = useState<PlayerAdjustmentRow[]>([]);
+  const [originalPlayers, setOriginalPlayers] = useState<PlayerAdjustmentRow[]>([]);
+  const [teams, setTeams] = useState<TeamOption[]>([]);
+  const [tiers, setTiers] = useState<TierOption[]>([]);
+  const [shotHistory, setShotHistory] = useState<ShotHistoryRow[]>([]);
+  const [pendingUndoShots, setPendingUndoShots] = useState<Set<number>>(new Set());
+  const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     if (!isOpen) {
-      setActiveTab('Adjust Shots');
+      setActiveTab('adjustments');
       setIsSubmitConfirmationOpen(false);
+      setSeasonId(null);
+      setPlayers([]);
+      setOriginalPlayers([]);
+      setTeams([]);
+      setTiers([]);
+      setShotHistory([]);
+      setPendingUndoShots(new Set());
+      setLoading(true);
+      return;
     }
+
+    const fetchSeasonData = async () => {
+      setLoading(true);
+      try {
+        const { data: activeSeason, error: seasonError } = await supabase
+          .from('seasons')
+          .select('season_id')
+          .is('end_date', null)
+          .single();
+
+        if (seasonError || !activeSeason) {
+          console.error('No active season found:', seasonError);
+          setLoading(false);
+          return;
+        }
+
+        const activeSeasonId = activeSeason.season_id;
+        setSeasonId(activeSeasonId);
+
+        const [playerRes, teamRes, tierRes, shotsRes] = await Promise.all([
+          supabase
+            .from('player_instance')
+            .select('player_instance_id, player_id, shots_left, score, players(name, team_id, tier_id)')
+            .eq('season_id', activeSeasonId),
+          supabase.from('teams').select('team_id, team_name'),
+          supabase.from('tiers').select('tier_id, tier_name'),
+          supabase
+            .from('shots')
+            .select(
+              `shot_id, instance_id, shot_date, result, player_instance:instance_id (player_instance_id, season_id, players(name))`
+            )
+            .eq('player_instance.season_id', activeSeasonId)
+            .order('shot_date', { ascending: true }),
+        ]);
+
+        if (playerRes.error) {
+          console.error('Error fetching player instances:', playerRes.error);
+        }
+
+        if (teamRes.error) {
+          console.error('Error fetching teams:', teamRes.error);
+        }
+
+        if (tierRes.error) {
+          console.error('Error fetching tiers:', tierRes.error);
+        }
+
+        if (shotsRes.error) {
+          console.error('Error fetching shots:', shotsRes.error);
+        }
+
+        const playerRows: PlayerAdjustmentRow[] = (playerRes.data || []).map((player) => ({
+          key: `existing-${player.player_instance_id}`,
+          playerInstanceId: player.player_instance_id,
+          playerId: player.player_id,
+          name: player.players?.name ?? 'Unknown Player',
+          shotsLeft: player.shots_left ?? 0,
+          score: player.score ?? 0,
+          teamId: player.players?.team_id ?? null,
+          tierId: player.players?.tier_id ?? null,
+          isNew: false,
+        }));
+
+        setPlayers(playerRows);
+        setOriginalPlayers(playerRows);
+        setTeams(teamRes.data || []);
+        setTiers(tierRes.data || []);
+
+        const shotCounts = new Map<number, number>();
+        const shotsWithNumbers: ShotHistoryRow[] = (shotsRes.data || []).map((shot) => {
+          const instanceId = shot.instance_id;
+          const currentCount = shotCounts.get(instanceId) ?? 0;
+          const shotNumber = currentCount + 1;
+          shotCounts.set(instanceId, shotNumber);
+
+          return {
+            shotId: shot.shot_id,
+            instanceId,
+            playerName: shot.player_instance?.players?.name ?? 'Unknown Player',
+            shotNumber,
+            points: Number(shot.result) || 0,
+            shotDate: shot.shot_date,
+          };
+        });
+
+        shotsWithNumbers.sort((a, b) => new Date(b.shotDate).getTime() - new Date(a.shotDate).getTime());
+        setShotHistory(shotsWithNumbers);
+      } catch (error) {
+        console.error('Unexpected error fetching season data:', error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchSeasonData();
   }, [isOpen]);
 
   const handleCloseModal = () => {
@@ -44,26 +173,192 @@ const CurrentSeasonModal: React.FC<CurrentSeasonModalProps> = ({ isOpen, onClose
     setIsSubmitConfirmationOpen(true);
   };
 
-  const handleConfirmSubmitChanges = () => {
-    setIsSubmitConfirmationOpen(false);
-    onClose();
+  const pendingUndoSummary = useMemo(() => {
+    const summary = new Map<number, { shotsToRefund: number; scoreToRemove: number }>();
+    shotHistory.forEach((shot) => {
+      if (!pendingUndoShots.has(shot.shotId)) return;
+      const current = summary.get(shot.instanceId) ?? { shotsToRefund: 0, scoreToRemove: 0 };
+      summary.set(shot.instanceId, {
+        shotsToRefund: current.shotsToRefund + 1,
+        scoreToRemove: current.scoreToRemove + shot.points,
+      });
+    });
+    return summary;
+  }, [pendingUndoShots, shotHistory]);
+
+  const hasChanges = useMemo(() => {
+    if (pendingUndoShots.size > 0) return true;
+    if (players.some((player) => player.isNew)) return true;
+
+    const originalMap = new Map(
+      originalPlayers.map((player) => [player.playerInstanceId, player])
+    );
+
+    return players.some((player) => {
+      if (player.isNew) return true;
+      const original = originalMap.get(player.playerInstanceId);
+      if (!original) return true;
+      return (
+        original.name !== player.name ||
+        original.shotsLeft !== player.shotsLeft ||
+        original.score !== player.score ||
+        original.teamId !== player.teamId ||
+        original.tierId !== player.tierId
+      );
+    });
+  }, [originalPlayers, pendingUndoShots.size, players]);
+
+  const handlePlayerFieldChange = <T extends keyof PlayerAdjustmentRow>(
+    key: string,
+    field: T,
+    value: PlayerAdjustmentRow[T]
+  ) => {
+    setPlayers((prev) =>
+      prev.map((player) => (player.key === key ? { ...player, [field]: value } : player))
+    );
   };
 
-  const controls = [
-    { key: 'Adjust Shots', label: 'Adjust Shots', description: 'Update shot attempts and completions.' },
-    { key: 'Teams', label: 'Team/Player Edit', description: 'Manage teams and player rosters.' },
-    { key: 'Adjust Scores', label: 'Adjust Scores', description: 'Modify scores and results.' },
-    { key: 'Tier Adjust', label: 'Tier Adjust', description: 'Reassign teams to tiers.' },
-    { key: 'Add Player', label: 'Add Player', description: 'Add new players to the season.' },
-    { key: 'Adjust Rules', label: 'Adjust Rules', description: 'Update season rules and guidelines.' },
-  ];
+  const handleAddPlayerRow = () => {
+    const newKey = `new-${Date.now()}`;
+    const newRow: PlayerAdjustmentRow = {
+      key: newKey,
+      name: '',
+      shotsLeft: 0,
+      score: 0,
+      teamId: null,
+      tierId: null,
+      isNew: true,
+    };
+    setPlayers((prev) => [newRow, ...prev]);
+  };
 
-  const handleQuickActionChange = (key: string) => {
-    setActiveTab(key);
+  const handleRemoveNewPlayer = (key: string) => {
+    setPlayers((prev) => prev.filter((player) => player.key !== key));
+  };
+
+  const togglePendingUndo = (shotId: number) => {
+    setPendingUndoShots((prev) => {
+      const next = new Set(prev);
+      if (next.has(shotId)) {
+        next.delete(shotId);
+      } else {
+        next.add(shotId);
+      }
+      return next;
+    });
+  };
+
+  const handleConfirmSubmitChanges = async () => {
+    if (!seasonId) return;
+    setIsSaving(true);
+
+    try {
+      const undoMap = pendingUndoSummary;
+      const originalMap = new Map(
+        originalPlayers.map((player) => [player.playerInstanceId, player])
+      );
+
+      const playerUpdates = [] as PromiseLike<{ error: any }>[];
+      const instanceUpdates = [] as PromiseLike<{ error: any }>[];
+
+      for (const player of players) {
+        if (player.isNew) continue;
+        const original = originalMap.get(player.playerInstanceId);
+        if (!original || !player.playerId || !player.playerInstanceId) continue;
+
+        const undoSummary = undoMap.get(player.playerInstanceId) ?? {
+          shotsToRefund: 0,
+          scoreToRemove: 0,
+        };
+        const finalShotsLeft = player.shotsLeft + undoSummary.shotsToRefund;
+        const finalScore = player.score - undoSummary.scoreToRemove;
+
+        if (
+          original.name !== player.name ||
+          original.teamId !== player.teamId ||
+          original.tierId !== player.tierId
+        ) {
+          playerUpdates.push(
+            supabase
+              .from('players')
+              .update({
+                name: player.name.trim() || 'Unknown Player',
+                team_id: player.teamId,
+                tier_id: player.tierId,
+              })
+              .eq('player_id', player.playerId)
+          );
+        }
+
+        if (original.shotsLeft !== finalShotsLeft || original.score !== finalScore) {
+          instanceUpdates.push(
+            supabase
+              .from('player_instance')
+              .update({
+                shots_left: finalShotsLeft,
+                score: finalScore,
+              })
+              .eq('player_instance_id', player.playerInstanceId)
+          );
+        }
+      }
+
+      for (const player of players.filter((row) => row.isNew)) {
+        const trimmedName = player.name.trim();
+        if (!trimmedName) continue;
+
+        const { data: createdPlayer, error: createPlayerError } = await supabase
+          .from('players')
+          .insert({
+            name: trimmedName,
+            team_id: player.teamId,
+            tier_id: player.tierId,
+          })
+          .select('player_id')
+          .single();
+
+        if (createPlayerError || !createdPlayer) {
+          console.error('Error adding player:', createPlayerError);
+          continue;
+        }
+
+        const { error: instanceError } = await supabase.from('player_instance').insert({
+          player_id: createdPlayer.player_id,
+          season_id: seasonId,
+          shots_left: player.shotsLeft,
+          score: player.score,
+        });
+
+        if (instanceError) {
+          console.error('Error adding player instance:', instanceError);
+        }
+      }
+
+      const updateResults = await Promise.all([...playerUpdates, ...instanceUpdates]);
+      updateResults.forEach((result) => {
+        if (result?.error) {
+          console.error('Error saving changes:', result.error);
+        }
+      });
+
+      if (pendingUndoShots.size > 0) {
+        const shotIds = Array.from(pendingUndoShots);
+        const { error: deleteError } = await supabase.from('shots').delete().in('shot_id', shotIds);
+        if (deleteError) {
+          console.error('Error deleting shots:', deleteError);
+        }
+      }
+
+      setIsSubmitConfirmationOpen(false);
+      onClose();
+    } catch (error) {
+      console.error('Unexpected error applying changes:', error);
+    } finally {
+      setIsSaving(false);
+    }
   };
 
   return (
-    // Modal container with dynamic class based on `isOpen` prop
     <div
       className={`${styles.currentSeasonModal} ${isOpen ? styles.currentSeasonModalOpen : ''}`}
       role="dialog"
@@ -82,94 +377,257 @@ const CurrentSeasonModal: React.FC<CurrentSeasonModalProps> = ({ isOpen, onClose
           <div>
             <h2 className={styles.title}>Current Season Controls</h2>
             <p className={styles.subtitle}>
-              Make all edits in one place, then submit to apply them. Nothing is changed until you confirm.
+              Draft adjustments and history edits here. Nothing is applied until you submit.
             </p>
           </div>
         </div>
 
-        <div className={styles.tableWrapper}>
-          <div className={styles.tableHeader}>
-            <div>
-              <p className={styles.tableTitle}>Select a control to edit</p>
-              <p className={styles.tableHelp}>Use the inline dropdown or the edit buttons to open a section.</p>
-            </div>
-            <div className={styles.quickSelect}>
-              <label htmlFor="controlSelect">Jump to:</label>
-              <select
-                id="controlSelect"
-                value={activeTab}
-                onChange={(e) => handleQuickActionChange(e.target.value)}
-                className={styles.select}
-              >
-                {controls.map((control) => (
-                  <option key={control.key} value={control.key}>
-                    {control.label}
-                  </option>
-                ))}
-              </select>
-            </div>
-          </div>
-
-          <table className={styles.controlsTable}>
-            <thead>
-              <tr>
-                <th scope="col">Control</th>
-                <th scope="col">Description</th>
-                <th scope="col">Action</th>
-                <th scope="col">Status</th>
-              </tr>
-            </thead>
-            <tbody>
-              {controls.map((control) => (
-                <tr key={control.key} className={activeTab === control.key ? styles.activeRow : ''}>
-                  <td>{control.label}</td>
-                  <td>{control.description}</td>
-                  <td>
-                    <div className={styles.inlineActions}>
-                      <select
-                        aria-label={`Choose action for ${control.label}`}
-                        className={styles.select}
-                        value={activeTab === control.key ? 'Edit' : 'View'}
-                        onChange={() => handleQuickActionChange(control.key)}
-                      >
-                        <option value="View">View</option>
-                        <option value="Edit">Edit</option>
-                      </select>
-                      <button
-                        className={styles.inlineEditBtn}
-                        onClick={() => handleQuickActionChange(control.key)}
-                        aria-label={`Open ${control.label}`}
-                      >
-                        Open
-                      </button>
-                    </div>
-                  </td>
-                  <td>{activeTab === control.key ? 'Editing' : 'Idle'}</td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
+        <div className={styles.tabBar} role="tablist" aria-label="Current season sections">
+          <button
+            className={`${styles.tabButton} ${activeTab === 'adjustments' ? styles.activeTab : ''}`}
+            onClick={() => setActiveTab('adjustments')}
+            role="tab"
+            aria-selected={activeTab === 'adjustments'}
+            aria-controls="season-adjustments"
+          >
+            Season adjustments
+          </button>
+          <button
+            className={`${styles.tabButton} ${activeTab === 'history' ? styles.activeTab : ''}`}
+            onClick={() => setActiveTab('history')}
+            role="tab"
+            aria-selected={activeTab === 'history'}
+            aria-controls="shot-history"
+          >
+            Shot history
+          </button>
         </div>
 
-        {/* Content area for the selected tab */}
         <div className={styles.contentWrapper}>
-          <div className={styles.content}>
-            {activeTab === 'Adjust Shots' && <AdjustShots isOpen={isOpen} />}
-            {activeTab === 'Teams' && <AdjustTeams isOpen={isOpen} />}
-            {activeTab === 'Adjust Scores' && <AdjustScores isOpen={isOpen} />}
-            {activeTab === 'Tier Adjust' && <AdjustTiers isOpen={isOpen} />}
-            {activeTab === 'Add Player' && <AddPlayers isOpen={isOpen} />}
-            {activeTab === 'Adjust Rules' && <AdjustRules isOpen={isOpen} />}
-          </div>
+          {loading ? (
+            <div className={styles.loadingState}>Loading current season data...</div>
+          ) : (
+            <div className={styles.content}>
+              {activeTab === 'adjustments' && (
+                <section id="season-adjustments" role="tabpanel" className={styles.tabPanel}>
+                  <div className={styles.panelHeader}>
+                    <div>
+                      <h3>Season adjustments</h3>
+                      <p>Update players, shots, scores, teams, and tiers in one inline table.</p>
+                    </div>
+                    <button className={styles.primaryBtn} onClick={handleAddPlayerRow}>
+                      + Add player
+                    </button>
+                  </div>
+
+                  <div className={styles.tableScroll}>
+                    <table className={styles.dataTable}>
+                      <thead>
+                        <tr>
+                          <th>Players</th>
+                          <th>Shots</th>
+                          <th>Score</th>
+                          <th>Team</th>
+                          <th>Tier</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {players.length === 0 && (
+                          <tr>
+                            <td colSpan={5} className={styles.emptyState}>
+                              No players found for the current season.
+                            </td>
+                          </tr>
+                        )}
+                        {players.map((player) => {
+                          const undoSummary = player.playerInstanceId
+                            ? pendingUndoSummary.get(player.playerInstanceId)
+                            : undefined;
+
+                          return (
+                            <tr key={player.key} className={player.isNew ? styles.newRow : ''}>
+                              <td>
+                                <div className={styles.playerCell}>
+                                  <input
+                                    type="text"
+                                    value={player.name}
+                                    placeholder="Player name"
+                                    onChange={(event) =>
+                                      handlePlayerFieldChange(player.key, 'name', event.target.value)
+                                    }
+                                  />
+                                  {player.isNew && (
+                                    <button
+                                      type="button"
+                                      className={styles.linkButton}
+                                      onClick={() => handleRemoveNewPlayer(player.key)}
+                                    >
+                                      Remove
+                                    </button>
+                                  )}
+                                </div>
+                              </td>
+                              <td>
+                                <div className={styles.numericField}>
+                                  <input
+                                    type="number"
+                                    value={player.shotsLeft}
+                                    min={0}
+                                    onChange={(event) =>
+                                      handlePlayerFieldChange(
+                                        player.key,
+                                        'shotsLeft',
+                                        Number(event.target.value)
+                                      )
+                                    }
+                                  />
+                                  {undoSummary && undoSummary.shotsToRefund > 0 && (
+                                    <span className={styles.pendingNote}>
+                                      +{undoSummary.shotsToRefund} pending undo
+                                    </span>
+                                  )}
+                                </div>
+                              </td>
+                              <td>
+                                <div className={styles.numericField}>
+                                  <input
+                                    type="number"
+                                    value={player.score}
+                                    min={0}
+                                    onChange={(event) =>
+                                      handlePlayerFieldChange(
+                                        player.key,
+                                        'score',
+                                        Number(event.target.value)
+                                      )
+                                    }
+                                  />
+                                  {undoSummary && undoSummary.scoreToRemove > 0 && (
+                                    <span className={styles.pendingNote}>
+                                      -{undoSummary.scoreToRemove} pending undo
+                                    </span>
+                                  )}
+                                </div>
+                              </td>
+                              <td>
+                                <select
+                                  value={player.teamId ?? ''}
+                                  onChange={(event) =>
+                                    handlePlayerFieldChange(
+                                      player.key,
+                                      'teamId',
+                                      event.target.value ? Number(event.target.value) : null
+                                    )
+                                  }
+                                >
+                                  <option value="">No Team</option>
+                                  {teams.map((team) => (
+                                    <option key={team.team_id} value={team.team_id}>
+                                      {team.team_name || 'Unknown Team'}
+                                    </option>
+                                  ))}
+                                </select>
+                              </td>
+                              <td>
+                                <select
+                                  value={player.tierId ?? ''}
+                                  onChange={(event) =>
+                                    handlePlayerFieldChange(
+                                      player.key,
+                                      'tierId',
+                                      event.target.value ? Number(event.target.value) : null
+                                    )
+                                  }
+                                >
+                                  <option value="">No Tier</option>
+                                  {tiers.map((tier) => (
+                                    <option key={tier.tier_id} value={tier.tier_id}>
+                                      {tier.tier_name || 'Unknown Tier'}
+                                    </option>
+                                  ))}
+                                </select>
+                              </td>
+                            </tr>
+                          );
+                        })}
+                      </tbody>
+                    </table>
+                  </div>
+                </section>
+              )}
+
+              {activeTab === 'history' && (
+                <section id="shot-history" role="tabpanel" className={styles.tabPanel}>
+                  <div className={styles.panelHeader}>
+                    <div>
+                      <h3>Shot history</h3>
+                      <p>Review every shot recorded this season. Undo shots before submitting changes.</p>
+                    </div>
+                    {pendingUndoShots.size > 0 && (
+                      <div className={styles.pendingBadge}>
+                        {pendingUndoShots.size} undo{pendingUndoShots.size === 1 ? '' : 's'} queued
+                      </div>
+                    )}
+                  </div>
+
+                  <div className={styles.tableScroll}>
+                    <table className={styles.dataTable}>
+                      <thead>
+                        <tr>
+                          <th>Player</th>
+                          <th>Shot #</th>
+                          <th>Points</th>
+                          <th>Recorded</th>
+                          <th>Action</th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {shotHistory.length === 0 && (
+                          <tr>
+                            <td colSpan={5} className={styles.emptyState}>
+                              No shots recorded yet for this season.
+                            </td>
+                          </tr>
+                        )}
+                        {shotHistory.map((shot) => {
+                          const isPendingUndo = pendingUndoShots.has(shot.shotId);
+                          return (
+                            <tr key={shot.shotId} className={isPendingUndo ? styles.undoRow : ''}>
+                              <td>{shot.playerName}</td>
+                              <td>{shot.shotNumber}</td>
+                              <td>{shot.points}</td>
+                              <td>{new Date(shot.shotDate).toLocaleString()}</td>
+                              <td>
+                                <button
+                                  type="button"
+                                  className={styles.secondaryBtn}
+                                  onClick={() => togglePendingUndo(shot.shotId)}
+                                >
+                                  {isPendingUndo ? 'Restore' : 'Undo'}
+                                </button>
+                              </td>
+                            </tr>
+                          );
+                        })}
+                      </tbody>
+                    </table>
+                  </div>
+                </section>
+              )}
+            </div>
+          )}
         </div>
 
-        {/* Bottom bar with controls */}
         <div className={styles.bottomBar}>
-          <button className={styles.secondaryBtn} onClick={handleCloseModal}>
+          <button className={styles.secondaryBtn} onClick={handleCloseModal} disabled={isSaving}>
             Close
           </button>
-          <button className={styles.primaryBtn} onClick={handleSubmitChanges}>
-            Submit changes
+          <button
+            className={styles.primaryBtn}
+            onClick={handleSubmitChanges}
+            disabled={!hasChanges || isSaving}
+          >
+            {isSaving ? 'Saving...' : 'Submit changes'}
           </button>
         </div>
       </div>
@@ -183,7 +641,11 @@ const CurrentSeasonModal: React.FC<CurrentSeasonModalProps> = ({ isOpen, onClose
               <button className={styles.secondaryBtn} onClick={() => setIsSubmitConfirmationOpen(false)}>
                 Keep editing
               </button>
-              <button className={styles.primaryBtn} onClick={handleConfirmSubmitChanges}>
+              <button
+                className={styles.primaryBtn}
+                onClick={handleConfirmSubmitChanges}
+                disabled={isSaving}
+              >
                 Submit and close
               </button>
             </div>


### PR DESCRIPTION
### Motivation
- Replace the existing single-list controls UI with a purpose-built interface for editing the active season in one place.
- Provide an inline editing surface so admins can stage multiple changes (players, shots, scores, team, tier) and only apply them on explicit submit.
- Make it easy to undo recent shot entries from the season via a shot history view, without applying changes immediately.
- Improve responsiveness and accessibility for the modal to work across screen sizes.

### Description
- Replaced the previous controls UI with a two-tab modal: `Season adjustments` and `Shot history` (`src/components/CurrentSeason/CurrentSeasonModal.tsx`).
- `Season adjustments` tab: inline editable table with columns for `Players`, `Shots`, `Score`, `Team`, and `Tier`, plus a `+ Add player` button that inserts a staged new-player row (does not persist until submit).
- `Shot history` tab: chronological shot list (most recent first) showing player, shot number, points and recorded date; shots can be staged for undo via an Undo/Restore action and are only deleted when the admin submits changes.
- Local staging and apply-on-submit behavior: changes (player edits, new players, player_instance updates, and queued shot deletions) are tracked client-side (`players`, `originalPlayers`, `pendingUndoShots`) and applied in batch to Supabase on confirm. The submission logic updates `players`, `player_instance`, inserts new players/instances, and deletes shot rows.
- UI/UX and accessibility updates in `CurrentSeasonModal.module.css`: responsive modal sizing, tab styling, loading states, disabled/confirm controls while saving, and ARIA attributes (`role="tablist"`, `role="tabpanel"`, etc.).

Files changed:
- `src/components/CurrentSeason/CurrentSeasonModal.tsx` — complete modal rework and submission logic
- `src/components/CurrentSeason/CurrentSeasonModal.module.css` — responsive styles, tab UI, tables and state styles

### Testing
- Started the dev server with `npm run dev`; Next.js reported ready (local dev server started). Success.
- Attempted an automated Playwright screenshot of `/Admin` to capture the modal, but the browser run failed with `net::ERR_CONNECTION_REFUSED` (Playwright could not connect to the dev server) despite restarting with `HOSTNAME=0.0.0.0`. Screenshot capture was not completed.
- No unit or integration test suite was run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69457066ba2c832ca740bed20b99f8a8)