### PR TITLE
Move season title into header and replace header icon with NBL logo

### DIFF
--- a/src/app/Standings/StandingsPage.module.css
+++ b/src/app/Standings/StandingsPage.module.css
@@ -120,13 +120,6 @@
   box-sizing: border-box;
 }
 
-.seasonTitle {
-  font-size: 3rem;
-  font-weight: bold;
-  color: #264653; /* Updated color for consistency */
-  text-align: center;
-  margin-bottom: 20px;
-}
 
 /* Teams container */
 .teams {

--- a/src/app/Standings/page.tsx
+++ b/src/app/Standings/page.tsx
@@ -487,13 +487,12 @@ const StandingsPage: React.FC = () => {
 
  return (
   <div className={styles.userContainer}>
-    <Header></Header>
+    <Header seasonTitle={`${season.season_name} Standings`} />
 
     {/* Main Content Section */}
     <main className={styles.userContent}>
         {/* Standings View*/}
         <div className={styles.container}>
-          <h2 className={styles.seasonTitle}>{season.season_name} Standings</h2>
           <div className={styles.teams}>
             {teams.map((team, index) => (
               <div key={index} className={styles.team}>

--- a/src/components/Header.module.css
+++ b/src/components/Header.module.css
@@ -26,22 +26,30 @@
     height: 64px;
   }
   /* Navbar styling */
-  .navbar {
-    width: 100%;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 8px 10px;
-    background-color: #264653; /* Darker color for better contrast */
-    color: white;
-    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-    flex-shrink: 0;
-    flex-wrap: wrap;
-    gap: 0.5rem;
-    position: sticky;
-    top: 0;
-    z-index: 1300;
-  }
+.navbar {
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 8px 10px;
+  background-color: #264653; /* Darker color for better contrast */
+  color: white;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  flex-shrink: 0;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  position: sticky;
+  top: 0;
+  z-index: 1300;
+}
+
+.seasonName {
+  font-size: 1.5rem;
+  font-weight: 600;
+  text-align: center;
+  color: #fff;
+  flex: 1;
+}
   .active {
     /* inverted color due to needing to invert the logo */
     border-bottom: 2px solid #000000; /* Highlight active tab */
@@ -55,9 +63,13 @@
   }
 
   @media (max-width: 900px) {
-    .navbarTitle {
-      font-size: 1.5rem;
-    }
+  .navbarTitle {
+    font-size: 1.5rem;
+  }
+
+  .seasonName {
+    font-size: 1.25rem;
+  }
 
     .navItem {
       width: 52px;
@@ -66,15 +78,20 @@
   }
 
   @media (max-width: 640px) {
-    .navbar {
-      justify-content: center;
-    }
+  .navbar {
+    justify-content: center;
+  }
 
-    .navMenu {
-      width: 100%;
-      justify-content: center;
-      gap: 0.35rem;
-    }
+  .navMenu {
+    width: 100%;
+    justify-content: center;
+    gap: 0.35rem;
+  }
+
+  .seasonName {
+    width: 100%;
+    order: 2;
+  }
 
     .navItem {
       width: 48px;

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,7 +3,7 @@ import styles from "./Header.module.css"
 
 import { usePathname, useRouter } from 'next/navigation';
 import Image from 'next/image'
-import bucketsLogo from "@/assets/images/buckets.png"
+import nblLogo from "@/assets/images/NBL Logo.png"
 import scoreLogo from "@/assets/images/add.png" 
 import standingsLogo from "@/assets/images/speedometer.png"
 import freeAgencyLogo from "@/assets/images/bench.png"
@@ -13,7 +13,11 @@ import userLogo from "@/assets/images/user.png"
 import adminLogo from "@/assets/images/administrator.png" 
 
 
-export default function Header() {
+interface HeaderProps {
+    seasonTitle?: string;
+}
+
+export default function Header({ seasonTitle }: HeaderProps) {
 
     const router = useRouter(); // Router for navigation
     const pathname = usePathname(); // Current pathname of the app
@@ -31,8 +35,8 @@ export default function Header() {
 
         <header className={styles.navbar}>
             <div className={styles.navMenu}>
-                <Image className={`${styles.navItem} invert`} 
-                            src={bucketsLogo}
+                <Image className={styles.navItem}
+                            src={nblLogo}
                             alt='Buckets!'
                             width="75"
                             height="75"
@@ -40,6 +44,9 @@ export default function Header() {
                 </Image>
                 <h1 className={`${styles.navbarTitle}`}>Buckets</h1>
             </div>
+            {seasonTitle ? (
+                <div className={styles.seasonName}>{seasonTitle}</div>
+            ) : null}
             <nav className={styles.navMenu}>
                 {/* Navigation Buttons */}
                 <div className="relative group">


### PR DESCRIPTION
### Motivation
- Make more room in the Standings grid by moving the season name into the top blue header bar. 
- Replace the basketball net placeholder with the official NBL logo from the project's assets. 
- Keep the header responsive and preserve existing navigation behavior. 

### Description
- Replaced the header logo import and usage in `src/components/Header.tsx` to use `@/assets/images/NBL Logo.png` and removed the old buckets logo. 
- Added an optional `seasonTitle` prop to `Header` and render the season title in the header when provided. 
- Updated `src/components/Header.module.css` to add `.seasonName` styling and responsive rules for centered placement. 
- Updated `src/app/Standings/page.tsx` to pass `seasonTitle={`${season.season_name} Standings`}` to `Header` and removed the in-page season heading, and removed the redundant `.seasonTitle` rules from `src/app/Standings/StandingsPage.module.css`. 

### Testing
- Started the dev server with `npm run dev` and compiled the Standings page successfully (Next fell back to a local font after a Google Fonts fetch error). 
- Performed an automated page visit to `/Standings` and received a `200` response. 
- Captured an automated screenshot of the Standings header at `artifacts/standings-header.png`. 
- Changes were committed locally after verification that the app compiled and the page rendered.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695adf96d228832c9354fdbcf58b6ac3)