### PR TITLE
Display team logos on Standings page

### DIFF
--- a/src/app/Standings/StandingsPage.module.css
+++ b/src/app/Standings/StandingsPage.module.css
@@ -198,7 +198,21 @@
   text-align: center;
   font-size: 2rem;
   font-weight: bold;
+  margin: 0;
+}
+
+.teamHeader {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
   margin-bottom: 10px;
+}
+
+.teamLogo {
+  width: auto;
+  height: 48px;
+  object-fit: contain;
 }
 
 /* Header row for player stats */

--- a/src/app/Standings/page.tsx
+++ b/src/app/Standings/page.tsx
@@ -5,8 +5,13 @@ import { supabase } from '@/supabaseClient';
 import { FaFireFlameCurved } from "react-icons/fa6";
 import { FaSnowflake } from "react-icons/fa6"; 
 import { useRouter } from 'next/navigation';
+import Image, { StaticImageData } from 'next/image';
 
 import Header from '@/components/Header';
+import direwolvesLogo from '@/assets/images/Direwolves - Clear BG (1).png';
+import monstarsLogo from '@/assets/images/Monstars - Clear BG.png';
+import nightmaresLogo from '@/assets/images/Nightmares - Clear BG Needs Fixed.png';
+import spartansLogo from '@/assets/images/Spartans-hoodie-illustrated-transparent-small.png';
 
 interface Team {
   team_id: number;
@@ -39,6 +44,13 @@ interface Season {
   shot_total: number;
   rules: string;
 }
+
+const teamLogoMap: Record<string, StaticImageData> = {
+  Direwolves: direwolvesLogo,
+  Monstars: monstarsLogo,
+  Nightmares: nightmaresLogo,
+  Spartans: spartansLogo,
+};
 
 
 
@@ -497,7 +509,18 @@ const StandingsPage: React.FC = () => {
             {teams.map((team, index) => (
               <div key={index} className={styles.team}>
                 {/* Team Title */}
-                <h2 className={styles.teamTitle}>{team.team_name}</h2>
+                <div className={styles.teamHeader}>
+                  {teamLogoMap[team.team_name] && (
+                    <Image
+                      className={styles.teamLogo}
+                      src={teamLogoMap[team.team_name]}
+                      alt={`${team.team_name} logo`}
+                      width={48}
+                      height={48}
+                    />
+                  )}
+                  <h2 className={styles.teamTitle}>{team.team_name}</h2>
+                </div>
                 <div className={styles.teamStatsGrid}>
                   <div className={styles.statBox}>
                     <span className={styles.statLabel}>Total Score</span>


### PR DESCRIPTION
### Motivation

- Replace textual team names with their visual logos on the Standings page to match admin selections and improve clarity.
- Use the existing project asset images so team identity is consistent across the app.

### Description

- Import team logo assets and add a `teamLogoMap` mapping team names to image modules.
- Render a `next/image` logo next to each team title inside a new `.teamHeader` wrapper in `Standings/page.tsx`.
- Add `.teamHeader` and `.teamLogo` styles and adjust `.teamTitle` spacing in `StandingsPage.module.css`.
- Use `StaticImageData` typing for the logo map to keep TypeScript typings correct.

### Testing

- Ran `npm run dev` and confirmed the app compiled and served the `/Standings` page (Next.js fell back when Google Fonts could not be fetched).
- Captured a visual verification screenshot of `http://127.0.0.1:3000/Standings` using Playwright and saved it as `artifacts/standings-logos.png`.
- No automated unit tests were added or run for this visual/frontend change.
- Manual visual inspection verified logos appear next to team titles for mapped team names.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ae22c79a8832cb31aaaea4fc62d89)