### PR TITLE
Add tier gradient behind player names

### DIFF
--- a/src/app/Standings/StandingsPage.module.css
+++ b/src/app/Standings/StandingsPage.module.css
@@ -84,6 +84,9 @@
   gap: 6px;
   white-space: nowrap;
   overflow: visible;
+  padding: 4px 10px;
+  border-radius: 999px;
+  color: #1f2933;
 }
 
 .playerNameText {
@@ -244,12 +247,6 @@
   min-width: 0;
 }
 
-.colorCircle {
-  width: 10px !important; /* Ensure width is enforced */
-  height: 10px !important; /* Ensure height is enforced */
-  border-radius: 50%;
-  margin-right: 8px;
-}
 .signOutButton:hover {
   background-color: #a11a1a;
   box-shadow: 0 6px 10px rgba(0, 0, 0, 0.15);

--- a/src/app/Standings/page.tsx
+++ b/src/app/Standings/page.tsx
@@ -546,12 +546,12 @@ const StandingsPage: React.FC = () => {
                   <div key={playerIndex} className={styles.row}>
                     {/* Player Name and Icons */}
                     <div className={styles.playerNameColumn}>
-                      <div className={styles.playerName}>
-                        {/* Tier Color Indicator */}
-                        <span
-                          className={styles.colorCircle}
-                          style={{ backgroundColor: player.tier_color }}
-                        />
+                      <div
+                        className={styles.playerName}
+                        style={{
+                          backgroundImage: `linear-gradient(90deg, ${player.tier_color}33 0%, ${player.tier_color}1A 60%, transparent 100%)`,
+                        }}
+                      >
                         <span className={styles.playerNameText}>{player.name}</span>
                         {player.name === 'A. Begy' && (
                           <span className={styles.crownIcon}>👑</span>


### PR DESCRIPTION
### Motivation
- Replace the small tier color dot with a wider, more visible gradient behind the player name to indicate the tier they shoot from.
- Keep the player name highly readable on top of the new background.
- Apply the change for the Standings view so tier information is clearer at a glance.

### Description
- Updated `src/app/Standings/page.tsx` to remove the dot and apply an inline `backgroundImage` gradient using the player's `tier_color`, e.g. `linear-gradient(90deg, ${player.tier_color}33 0%, ${player.tier_color}1A 60%, transparent 100%)` behind the name.
- Modified `src/app/Standings/StandingsPage.module.css` to style `.playerName` with `padding`, `border-radius`, and a readable text `color`, and removed the `.colorCircle` rule.
- Changes are limited to the Standings UI; no data or API behavior was modified.

### Testing
- Started the dev server with `npm run dev` and compiled the Standings page successfully, though fetching the `Inter` Google Font failed and a fallback font was used (font fetch retries reported and fallback applied).
- Executed a Playwright script that navigated to `/Standings` and captured a screenshot to `artifacts/standings-gradient.png`, which completed successfully.
- No unit tests were executed for this UI change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ae4e380ac832c9c08ef8555ac0c9f)