### PR TITLE
Enlarge team logos on Standings page

### DIFF
--- a/src/app/Standings/StandingsPage.module.css
+++ b/src/app/Standings/StandingsPage.module.css
@@ -208,13 +208,13 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 12px;
-  margin-bottom: 10px;
+  gap: 16px;
+  margin-bottom: 14px;
 }
 
 .teamLogo {
   width: auto;
-  height: 48px;
+  height: 96px;
   object-fit: contain;
 }
 


### PR DESCRIPTION
### Motivation
- Logos on the Standings page were too small to read and needed to be more prominent for better readability.
- The layout needed small spacing adjustments to accommodate larger logos without breaking alignment.

### Description
- Increased the team logo height by changing `.teamLogo` from `height: 48px` to `height: 96px` in `StandingsPage.module.css`.
- Adjusted header spacing by updating `.teamHeader` `gap` to `16px` and `margin-bottom` to `14px` to better fit the larger logos.
- No functional behavior changes; only presentation (CSS) updates were made.

### Testing
- Started the Next.js dev server and compiled the `/Standings` page successfully (page returned `200`).
- A Playwright script loaded the `/Standings` page and produced a screenshot artifact confirming larger logos were rendered.
- The build logged a font fetch warning for `Inter` from Google Fonts but fell back and compilation completed successfully.
- No unit tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ae6b4833c832cb746b99634975bad)