### PR TITLE
Allow current season modal scrolling

### DIFF
--- a/src/components/CurrentSeason/CurrentSeasonModal.module.css
+++ b/src/components/CurrentSeason/CurrentSeasonModal.module.css
@@ -31,7 +31,8 @@
   flex-direction: column;
   position: relative;
   max-height: calc(100vh - 64px);
-  overflow: hidden;
+  overflow-y: auto;
+  overflow-x: hidden;
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
 }
 
@@ -145,6 +146,7 @@
 
 .contentWrapper {
   flex: 1;
+  min-height: 0;
   border: 1px dashed #e5e7eb;
   border-radius: 12px;
   padding: 16px;
@@ -153,6 +155,7 @@
 
 .content {
   flex: 1;
+  min-height: 0;
   padding: 4px;
   overflow-y: auto;
   background: white;


### PR DESCRIPTION
### Motivation
- The current season modal was clipped and not scrollable, preventing admins from accessing controls on smaller screens.
- Make the modal content accessible and responsive so edits can be made regardless of viewport size.

### Description
- Changed `.modalContent` to allow vertical scrolling by setting `overflow-y: auto` and `overflow-x: hidden`.
- Added `min-height: 0` to `.contentWrapper` and `.content` so flex children can shrink and allow internal scrolling.
- Kept modal sizing limits with `max-height: calc(100vh - 64px)` so the modal fits within the viewport.

### Testing
- Started the dev server with `npm run dev` and the app compiled (Google font fetch produced warnings but fallback font was used). 
- Ran Playwright automation to open the admin page and capture a screenshot of the current season modal, which completed and produced an artifact (`artifacts/current-season-modal-scroll.png`).
- One Chromium headless launch attempt failed in the environment, but a subsequent Firefox-based run succeeded in generating the screenshot. 
- No unit tests were modified or run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ae85c3d7c832c9dfbed2c221d838f)