### PR TITLE
Increase Standings team logo size by 75%

### DIFF
--- a/src/app/Standings/StandingsPage.module.css
+++ b/src/app/Standings/StandingsPage.module.css
@@ -214,7 +214,7 @@
 
 .teamLogo {
   width: auto;
-  height: 96px;
+  height: 168px;
   object-fit: contain;
 }
 


### PR DESCRIPTION
### Motivation
- Improve visibility and prominence of team logos on the Standings page by enlarging them by 75%.
- Make the logo sizing consistent while preserving aspect ratio with `width: auto` and `object-fit: contain`.

### Description
- Updated the `.teamLogo` height from `96px` to `168px` in `src/app/Standings/StandingsPage.module.css`.
- Kept `width: auto` and `object-fit: contain` to preserve aspect ratio and prevent distortion.
- Captured an updated screenshot of the `/Standings` page to confirm the visual change.

### Testing
- Ran `npm run dev` and the app compiled and served the `/Standings` page successfully with a `GET /Standings 200` response.
- Executed a Playwright script to navigate to `/Standings` and saved `artifacts/standings-logo-75-percent.png` to verify the UI update.
- During dev startup the `Inter` Google Font failed to download but the build fell back to a fallback font and compilation completed.
- No unit tests were run for this visual CSS change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695ae8d473a4832cbdcfa356ba56c38c)