### PR TITLE
Fix current season modal scrolling

### DIFF
--- a/src/components/CurrentSeason/CurrentSeasonModal.module.css
+++ b/src/components/CurrentSeason/CurrentSeasonModal.module.css
@@ -157,7 +157,6 @@
   flex: 1;
   min-height: 0;
   padding: 4px;
-  overflow-y: auto;
   background: white;
   border-radius: 12px;
   border: 1px solid #e5e7eb;


### PR DESCRIPTION
### Motivation
- The current season modal had its own inner scroll which prevented reaching lower controls when the modal was taller than the viewport.
- The intent is to make the modal behave as a single scrollable surface so users can access all sections from the Admin menu.

### Description
- Removed the nested scroll behavior by deleting `overflow-y: auto` from the `.content` rule in `src/components/CurrentSeason/CurrentSeasonModal.module.css`.
- This lets the modal container manage scrolling (single surface) so inner panels are reachable.

### Testing
- Started the dev server with `npm run dev` and the app compiled successfully.
- Ran a Playwright capture that loaded `/Admin` and produced a screenshot artifact, and the page compiled despite a Google Fonts fetch warning (fallback used).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695aee7a6ad0832c89fff4919ee3273a)