### PR TITLE
Improve shots left dashes controls

### DIFF
--- a/src/components/AdjustShotsDashes.module.css
+++ b/src/components/AdjustShotsDashes.module.css
@@ -68,3 +68,39 @@
 .adjustShotsDashes button:hover:not(:disabled) {
   background-color: #0056b3;
 }
+
+.adjustShotsDashes .adjustControls {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.adjustShotsDashes .dashCount {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.adjustShotsDashes .countValue {
+  min-width: 22px;
+  font-weight: 600;
+  font-size: 1rem;
+}
+
+.adjustShotsDashes .dashMarks {
+  display: inline-flex;
+  gap: 6px;
+  color: #666;
+  font-weight: 600;
+  font-size: 1.1rem;
+}
+
+.adjustShotsDashes .dashMark {
+  line-height: 1;
+}
+
+.adjustShotsDashes .emptyState {
+  padding: 24px;
+  color: #666;
+  font-style: italic;
+}

--- a/src/components/AdjustShotsDashes.tsx
+++ b/src/components/AdjustShotsDashes.tsx
@@ -17,9 +17,14 @@ interface PlayerDashRow {
   player_id: number;
   player_instance_id: number;
   shots_left_dashes: number;
-  players: {
-    name: string;
-  }[];
+  players:
+    | {
+        name: string;
+      }
+    | {
+        name: string;
+      }[]
+    | null;
 }
 
 const MIN_DASHES = 0;
@@ -56,7 +61,7 @@ const AdjustShotsDashes: React.FC<AdjustShotsDashesProps> = ({ isOpen }) => {
             players (name)
           `)
           .eq('season_id', activeSeason.season_id)
-          .order('player_id', { ascending: true });
+          .order('name', { foreignTable: 'players', ascending: true });
 
         if (playerError) {
           console.error('Error fetching player dash data:', playerError);
@@ -104,6 +109,13 @@ const AdjustShotsDashes: React.FC<AdjustShotsDashesProps> = ({ isOpen }) => {
     }
   };
 
+  const resolvePlayerName = (player: PlayerDashRow) => {
+    if (Array.isArray(player.players)) {
+      return player.players[0]?.name ?? 'Unknown player';
+    }
+    return player.players?.name ?? 'Unknown player';
+  };
+
   return (
     <div className={styles.adjustShotsDashes}>
       <h2>Shots Left Dashes</h2>
@@ -117,29 +129,56 @@ const AdjustShotsDashes: React.FC<AdjustShotsDashesProps> = ({ isOpen }) => {
               <tr>
                 <th>Player</th>
                 <th>Dashes</th>
+                <th>Adjust</th>
               </tr>
             </thead>
             <tbody>
-              {players.map((player) => (
-                <tr key={player.player_id}>
-                  <td>{player.players?.[0]?.name}</td>
-                  <td>
-                    <button
-                      onClick={() => handleAdjustDashes(player.player_id, -1)}
-                      disabled={(player.shots_left_dashes ?? 0) <= MIN_DASHES}
-                    >
-                      -
-                    </button>
-                    {player.shots_left_dashes ?? 0}
-                    <button
-                      onClick={() => handleAdjustDashes(player.player_id, 1)}
-                      disabled={(player.shots_left_dashes ?? 0) >= MAX_DASHES}
-                    >
-                      +
-                    </button>
+              {players.length === 0 ? (
+                <tr>
+                  <td colSpan={3} className={styles.emptyState}>
+                    No players found for the active season.
                   </td>
                 </tr>
-              ))}
+              ) : (
+                players.map((player) => {
+                  const dashCount = player.shots_left_dashes ?? 0;
+                  return (
+                    <tr key={player.player_instance_id}>
+                      <td>{resolvePlayerName(player)}</td>
+                      <td>
+                        <div className={styles.dashCount}>
+                          <span className={styles.countValue}>{dashCount}</span>
+                          <span className={styles.dashMarks} aria-label={`${dashCount} dashes`}>
+                            {Array.from({ length: dashCount }).map((_, index) => (
+                              <span key={index} className={styles.dashMark}>
+                                —
+                              </span>
+                            ))}
+                          </span>
+                        </div>
+                      </td>
+                      <td>
+                        <div className={styles.adjustControls}>
+                          <button
+                            onClick={() => handleAdjustDashes(player.player_id, -1)}
+                            disabled={dashCount <= MIN_DASHES}
+                            aria-label={`Remove dash from ${resolvePlayerName(player)}`}
+                          >
+                            -
+                          </button>
+                          <button
+                            onClick={() => handleAdjustDashes(player.player_id, 1)}
+                            disabled={dashCount >= MAX_DASHES}
+                            aria-label={`Add dash to ${resolvePlayerName(player)}`}
+                          >
+                            +
+                          </button>
+                        </div>
+                      </td>
+                    </tr>
+                  );
+                })
+              )}
             </tbody>
           </table>
         </div>


### PR DESCRIPTION
### Motivation
- Provide an admin view that lists players and their "shots left" dashes in separate columns with explicit plus/minus controls limited to a max of 2 dashes.
- Ensure rows are sorted by player name and that player name resolution is resilient to the shapes returned by Supabase.
- Surface an empty-state message when no players exist for the active season.

### Description
- Broadened the `PlayerDashRow.players` type to accept array, single object, or null and added a `resolvePlayerName` helper to display names safely.
- Updated the Supabase query ordering to `.order('name', { foreignTable: 'players', ascending: true })` to sort by player name.
- Reworked the table UI to show an explicit `Dashes` column with a numeric count and visual dash marks, added a separate `Adjust` column with +/- buttons clamped by `MIN_DASHES` and `MAX_DASHES`, and added an empty-state row.
- Added supporting CSS for `.adjustControls`, `.dashCount`, `.dashMarks`, `.dashMark`, `.countValue`, and `.emptyState` to style the new layout.

### Testing
- Started the dev server with `npm run dev` and the app compiled and served, although Google Fonts failed to fetch and a fallback font was used.
- Ran a Playwright script to capture the UI screenshot and produced `artifacts/shots-left-dashes.png` after a second attempt (first run timed out).
- No automated unit tests were added or executed as part of this change.
- Manual UI inspection was used to verify layout and controls in the dev server snapshot.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695af0ffa2ac832cb042bea803792aba)