### PR TITLE
Stop using non-existent `shots_left_dashes` DB column; manage dashes client-side

### DIFF
--- a/src/app/Standings/page.tsx
+++ b/src/app/Standings/page.tsx
@@ -29,7 +29,6 @@ interface TeamWithPlayers {
     tier_color: string | undefined;
     name: string;
     shots_left: number;
-    shots_left_dashes: number;
     player_score: number;
     pps: number;
     reached_score_at: string | null;
@@ -279,7 +278,7 @@ const StandingsPage: React.FC = () => {
             visiblePlayers.map(async (player: any) => {
               const { data: playerInstance, error: piError } = await supabase
                 .from('player_instance')
-                .select('player_instance_id, shots_left, score, shots_left_dashes')
+                .select('player_instance_id, shots_left, score')
                 .eq('player_id', player.player_id)
                 .eq('season_id', activeSeasonId)
                 .single();
@@ -296,7 +295,6 @@ const StandingsPage: React.FC = () => {
               return {
                 name: player.name,
                 shots_left: playerInstance.shots_left,
-                shots_left_dashes: playerInstance.shots_left_dashes ?? 0,
                 player_score: playerInstance.score,
                 shots_taken: shotsTaken,
                 pps: shotsTaken > 0 ? playerInstance.score / shotsTaken : 0,
@@ -577,13 +575,6 @@ const StandingsPage: React.FC = () => {
                     <span className={styles.totalPoints}>{player.player_score}</span>
                   <div className={styles.shotsLeft}>
                     <span className={styles.shotsLeftValue}>{player.shots_left}</span>
-                    {player.shots_left_dashes > 0 && (
-                      <span className={styles.shotsLeftDashes} aria-label={`${player.shots_left_dashes} shots left dashes`}>
-                        {Array.from({ length: player.shots_left_dashes }).map((_, dashIndex) => (
-                          <span key={dashIndex} className={styles.shotsLeftDash} aria-hidden="true" />
-                        ))}
-                      </span>
-                    )}
                   </div>
                   <span className={styles.pps}>{player.pps.toFixed(2)}</span>
                 </div>

--- a/src/components/AddPlayers.tsx
+++ b/src/components/AddPlayers.tsx
@@ -132,7 +132,6 @@ const AddPlayers: React.FC<AddPlayersProps> = ({ isOpen }) => {
         player_id: newPlayer.player_id,
         season_id: seasonId,
         shots_left: shotCount,
-        shots_left_dashes: 0,
         score: 0,
       });
 

--- a/src/components/AdjustShotsDashes.tsx
+++ b/src/components/AdjustShotsDashes.tsx
@@ -57,7 +57,6 @@ const AdjustShotsDashes: React.FC<AdjustShotsDashesProps> = ({ isOpen }) => {
           .select(`
             player_id,
             player_instance_id,
-            shots_left_dashes,
             players (name)
           `)
           .eq('season_id', activeSeason.season_id)
@@ -66,7 +65,11 @@ const AdjustShotsDashes: React.FC<AdjustShotsDashesProps> = ({ isOpen }) => {
         if (playerError) {
           console.error('Error fetching player dash data:', playerError);
         } else {
-          setPlayers((playerData || []) as PlayerDashRow[]);
+          const hydratedPlayers = (playerData || []).map((player) => ({
+            ...(player as PlayerDashRow),
+            shots_left_dashes: 0,
+          }));
+          setPlayers(hydratedPlayers);
         }
       } catch (error) {
         console.error('Unexpected error:', error);
@@ -91,22 +94,6 @@ const AdjustShotsDashes: React.FC<AdjustShotsDashesProps> = ({ isOpen }) => {
     });
 
     setPlayers(updatedPlayers);
-
-    const playerToUpdate = updatedPlayers.find((player) => player.player_id === playerId);
-
-    if (!playerToUpdate) {
-      console.error('Player not found when adjusting dashes');
-      return;
-    }
-
-    const { error } = await supabase
-      .from('player_instance')
-      .update({ shots_left_dashes: playerToUpdate.shots_left_dashes })
-      .eq('player_instance_id', playerToUpdate.player_instance_id);
-
-    if (error) {
-      console.error('Error updating shots left dashes:', error);
-    }
   };
 
   const resolvePlayerName = (player: PlayerDashRow) => {

--- a/src/components/NextSeason/NextSeason.tsx
+++ b/src/components/NextSeason/NextSeason.tsx
@@ -798,7 +798,6 @@ const NextSeasonModal: React.FC<NextSeasonModalProps> = ({ isOpen, onClose, onSt
           player_id: player.player_id,
           season_id: newSeasonId,
           shots_left: shotCount,
-          shots_left_dashes: 0,
           score: 0,
         }));
 

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -53,8 +53,7 @@ export const playerInstanceTable = pgTable('player_instance', {
   teamId: integer('team_id')
     .notNull()
     .references(() => teamsTable.teamId, { onDelete: 'cascade' }),
-  shotsLeft: integer('shots_left').notNull(),
-  shotsLeftDashes: integer('shots_left_dashes').notNull().default(0)
+  shotsLeft: integer('shots_left').notNull()
 });
 
 export const shotsTable = pgTable('shots', {


### PR DESCRIPTION
### Motivation
- The app was failing because it assumed a `shots_left_dashes` column existed on `player_instance`, causing Supabase errors. 
- Dashes are UI/admin state only and do not need to be persisted in the database schema. 
- Only existing tables/columns from the schema should be used to avoid runtime DB errors. 
- Keep the admin adjust view functional by managing dash counts in-app instead of reading/writing a missing DB column.

### Description
- Removed `shots_left_dashes` from `player_instance` selects and from the `player_instance` schema definition in `src/db/schema.ts`.
- Stopped inserting `shots_left_dashes` when creating player instances in `src/components/AddPlayers.tsx` and `src/components/NextSeason/NextSeason.tsx`.
- Hydrated fetched rows in `src/components/AdjustShotsDashes.tsx` with a local `shots_left_dashes: 0` value and removed DB update calls so adjustments are kept in-app.
- Removed rendering and querying that relied on `shots_left_dashes` from the standings view in `src/app/Standings/page.tsx`.

### Testing
- Started the dev server with `npm run dev -- --hostname 0.0.0.0 --port 3000` and the app compiled and served, with a Google Fonts fetch warning but fallback fonts used. 
- Ran an automated Playwright screenshot script which produced `artifacts/standings-no-dashes.png` showing the Standings page without DB-driven dashes. 
- No unit tests were added or executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695af414fad4832c8babcbcff8c7d5cf)