### PR TITLE
Persist shots-left dashes updates

### DIFF
--- a/src/components/AdjustShotsDashes.tsx
+++ b/src/components/AdjustShotsDashes.tsx
@@ -57,6 +57,7 @@ const AdjustShotsDashes: React.FC<AdjustShotsDashesProps> = ({ isOpen }) => {
           .select(`
             player_id,
             player_instance_id,
+            shots_left_dashes,
             players (name)
           `)
           .eq('season_id', activeSeason.season_id)
@@ -65,11 +66,7 @@ const AdjustShotsDashes: React.FC<AdjustShotsDashesProps> = ({ isOpen }) => {
         if (playerError) {
           console.error('Error fetching player dash data:', playerError);
         } else {
-          const hydratedPlayers = (playerData || []).map((player) => ({
-            ...(player as PlayerDashRow),
-            shots_left_dashes: 0,
-          }));
-          setPlayers(hydratedPlayers);
+          setPlayers(playerData || []);
         }
       } catch (error) {
         console.error('Unexpected error:', error);
@@ -94,6 +91,22 @@ const AdjustShotsDashes: React.FC<AdjustShotsDashesProps> = ({ isOpen }) => {
     });
 
     setPlayers(updatedPlayers);
+
+    const playerToUpdate = updatedPlayers.find((player) => player.player_id === playerId);
+
+    if (!playerToUpdate) {
+      console.error('Player not found when adjusting shots left dashes');
+      return;
+    }
+
+    const { error } = await supabase
+      .from('player_instance')
+      .update({ shots_left_dashes: playerToUpdate.shots_left_dashes })
+      .eq('player_instance_id', playerToUpdate.player_instance_id);
+
+    if (error) {
+      console.error('Error updating shots left dashes:', error);
+    }
   };
 
   const resolvePlayerName = (player: PlayerDashRow) => {


### PR DESCRIPTION
### Motivation
- Adjusting "shots left" dashes in the admin modal looked correct in the UI but changes were not saved and reverted to 0 when reopening.
- The component previously hydrated fetched players with a hardcoded `shots_left_dashes: 0` and never wrote adjustments back to the database.

### Description
- Include `shots_left_dashes` in the Supabase `.select` for `player_instance` so the component loads real dash counts.
- Stop overwriting fetched rows with a hardcoded zero and set state from the returned `playerData` via `setPlayers(playerData || [])`.
- Persist dash changes by updating `player_instance.shots_left_dashes` in `handleAdjustDashes` after local state is updated.
- Add error logs when a player cannot be found or the Supabase update fails.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695af727ee54832cb2f7853984d162a7)