### PR TITLE
Render shots-left dashes on Standings and adjust styling

### DIFF
--- a/src/app/Standings/StandingsPage.module.css
+++ b/src/app/Standings/StandingsPage.module.css
@@ -113,13 +113,15 @@
 .shotsLeftDashes {
   display: flex;
   gap: 4px;
+  margin-top: 2px;
 }
 
 .shotsLeftDash {
-  width: 14px;
-  height: 3px;
+  width: 16px;
+  height: 4px;
   border-radius: 999px;
-  background-color: #1f2933;
+  background-color: #52606d;
+  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
   display: inline-block;
 }
 

--- a/src/app/Standings/page.tsx
+++ b/src/app/Standings/page.tsx
@@ -29,6 +29,7 @@ interface TeamWithPlayers {
     tier_color: string | undefined;
     name: string;
     shots_left: number;
+    shots_left_dashes: number;
     player_score: number;
     pps: number;
     reached_score_at: string | null;
@@ -278,7 +279,7 @@ const StandingsPage: React.FC = () => {
             visiblePlayers.map(async (player: any) => {
               const { data: playerInstance, error: piError } = await supabase
                 .from('player_instance')
-                .select('player_instance_id, shots_left, score')
+                .select('player_instance_id, shots_left, shots_left_dashes, score')
                 .eq('player_id', player.player_id)
                 .eq('season_id', activeSeasonId)
                 .single();
@@ -292,9 +293,11 @@ const StandingsPage: React.FC = () => {
               );
               console.log(shotsMadeInRow, shotsMissedInRow);
               const shotsTaken = Math.max(0, activeSeason.shot_total - playerInstance.shots_left);
+              const shotsLeftDashes = Math.max(0, Math.min(2, playerInstance.shots_left_dashes ?? 0));
               return {
                 name: player.name,
                 shots_left: playerInstance.shots_left,
+                shots_left_dashes: shotsLeftDashes,
                 player_score: playerInstance.score,
                 shots_taken: shotsTaken,
                 pps: shotsTaken > 0 ? playerInstance.score / shotsTaken : 0,
@@ -575,6 +578,16 @@ const StandingsPage: React.FC = () => {
                     <span className={styles.totalPoints}>{player.player_score}</span>
                   <div className={styles.shotsLeft}>
                     <span className={styles.shotsLeftValue}>{player.shots_left}</span>
+                    {player.shots_left_dashes > 0 && (
+                      <span
+                        className={styles.shotsLeftDashes}
+                        aria-label={`${player.shots_left_dashes} shots left dashes`}
+                      >
+                        {Array.from({ length: player.shots_left_dashes }).map((_, index) => (
+                          <span key={index} className={styles.shotsLeftDash} />
+                        ))}
+                      </span>
+                    )}
                   </div>
                   <span className={styles.pps}>{player.pps.toFixed(2)}</span>
                 </div>


### PR DESCRIPTION
### Motivation
- Display the admin-configured shots-left dash marks on the Standings page beneath each player’s `shots_left` value to match the Current Season modal settings.
- Provide a clear, aesthetic visual indicator (0–2 dashes) under the SL column for quick scanning.

### Description
- Include `shots_left_dashes` in the `player_instance` query and add `shots_left_dashes` to the `TeamWithPlayers` player shape.
- Clamp the dash count to the 0–2 range (`Math.max(0, Math.min(2, ...))`) and return it with each player record.
- Render dash marks in the player row JSX using `Array.from({ length: ... })` with an accessible `aria-label` and add `.shotsLeftDashes` / `.shotsLeftDash` CSS rules.
- Adjust CSS for spacing, size, color, and a subtle shadow to make dashes visually pleasing and distinct from the shots-left number.

### Testing
- Started the dev server with `npm run dev` and compiled the app successfully (Standings compiled and served).
- Navigated to `/Standings` and captured a screenshot with a Playwright script to verify dashes render under SL values.
- The page returned `GET /Standings 200` and the UI change is visible in the generated screenshot; Google Fonts fetch produced a warning but fallback fonts were used and the page still rendered.
- No automated unit tests were added or run for this UI-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695af9d4fe14832c98f54c76be8d6eff)