### PR TITLE
Improve standings logo rendering

### DIFF
--- a/src/app/Standings/page.tsx
+++ b/src/app/Standings/page.tsx
@@ -518,8 +518,9 @@ const StandingsPage: React.FC = () => {
                       className={styles.teamLogo}
                       src={teamLogoMap[team.team_name]}
                       alt={`${team.team_name} logo`}
-                      width={48}
-                      height={48}
+                      width={168}
+                      height={168}
+                      sizes="168px"
                     />
                   )}
                   <h2 className={styles.teamTitle}>{team.team_name}</h2>


### PR DESCRIPTION
### Motivation

- Team logos on the Standings page appeared blurry because small requested sizes caused upscaling of source assets.
- The goal is to request the intended display resolution so Next.js serves the correct image size and preserves clarity.

### Description

- Updated the `Image` component for team logos in `src/app/Standings/page.tsx` to use larger dimensions for display.
- Set `width={168}`, `height={168}`, and added `sizes="168px"` on the team logo `Image` to avoid low-resolution upscaling.
- No other layout or styling changes were made.

### Testing

- Started the dev server with `npm run dev -- --hostname 0.0.0.0 --port 3000` which compiled and served `GET /Standings` returning 200.
- Captured a screenshot using a Playwright script which saved `artifacts/standings-logos.png` to verify logos render at the new size.
- Note: Google Fonts failed to download during the dev run and Next used a fallback font, but the page compiled successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695afbaa940c832ca4f3dfa40cb5800c)