### PR TITLE
Add dash indicator and 'Use Dash' toggle to player modal, restyle submit button

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -26,8 +26,10 @@ const Modal: React.FC<ModalProps> = ({ name, isOpen, onClose, playerId }) => {
   const [currentScore, setCurrentScore] = useState<number>(0); // Current score of the player
   const [tierId, setTierId] = useState<number | null>(null); // Tier ID of the player
   const [shotsLeft, setShotsLeft] = useState<number | null>(null); // Remaining shots for the player
+  const [shotsLeftDashes, setShotsLeftDashes] = useState<number | null>(null); // Remaining dash shots
   const [shotsTakenToday, setShotsTakenToday] = useState<number | null>(null); // Shots taken in the current calendar day
   const [todaysScore, setTodaysScore] = useState<number | null>(null); // Points earned today
+  const [useDash, setUseDash] = useState<boolean>(false); // Spend a dash on submit
   const sound = new Howl({ src: ['/sounds/shot.mp3'] }); // Sound effect for shots
   const shotSound = useMemo(() => new Howl({ src: ['/sounds/onfire.mp3'] }), []);
   const sadsound = useMemo(() => new Howl({ src: ['/sounds/sadtrombone.mp3'] }), []); // Sound effect for sad events
@@ -65,8 +67,10 @@ const Modal: React.FC<ModalProps> = ({ name, isOpen, onClose, playerId }) => {
     setPlayerInstanceId(null);
     setTierId(null);
     setShotsLeft(null);
+    setShotsLeftDashes(null);
     setShotsTakenToday(null);
     setTodaysScore(null);
+    setUseDash(false);
   };
   const calculateShotsMadeInRow = async (playerInstanceId: number) => {
     try {
@@ -200,7 +204,7 @@ const Modal: React.FC<ModalProps> = ({ name, isOpen, onClose, playerId }) => {
       // Fetch player instance details
       const { data: playerInstance, error: instanceError } = await supabase
         .from('player_instance')
-        .select('player_instance_id, score, shots_left')
+        .select('player_instance_id, score, shots_left, shots_left_dashes')
         .eq('player_id', playerId)
         .eq('season_id', currentSeason.season_id)
         .single();
@@ -214,6 +218,7 @@ const Modal: React.FC<ModalProps> = ({ name, isOpen, onClose, playerId }) => {
       setPlayerInstanceId(playerInstance.player_instance_id);
       setCurrentScore(playerInstance.score);
       setShotsLeft(playerInstance.shots_left);
+      setShotsLeftDashes(playerInstance.shots_left_dashes ?? 0);
       fetchShotsTakenToday(playerInstance.player_instance_id);
 
       // Fetch the player's tier ID
@@ -260,6 +265,12 @@ const Modal: React.FC<ModalProps> = ({ name, isOpen, onClose, playerId }) => {
     setIsMoneyball(isMoneyballShot);
   }, [shotsLeft]);
 
+  useEffect(() => {
+    if (!shotsLeftDashes) {
+      setUseDash(false);
+    }
+  }, [shotsLeftDashes]);
+
   /**
    * Handles the submission of the shot and updates player data in the database.
    */
@@ -291,10 +302,15 @@ const Modal: React.FC<ModalProps> = ({ name, isOpen, onClose, playerId }) => {
   
       const newScore = currentScore + finalPoints;
       const newShotsLeft = (shotsLeft || 0) - 1;
-  
+      const nextShotsLeftDashes = Math.max(0, (shotsLeftDashes ?? 0) - (useDash ? 1 : 0));
+
       const { error: updateScoreError } = await supabase
         .from('player_instance')
-        .update({ score: newScore, shots_left: newShotsLeft })
+        .update({
+          score: newScore,
+          shots_left: newShotsLeft,
+          shots_left_dashes: nextShotsLeftDashes,
+        })
         .eq('player_instance_id', playerInstanceId);
   
       if (updateScoreError) {
@@ -369,6 +385,17 @@ const Modal: React.FC<ModalProps> = ({ name, isOpen, onClose, playerId }) => {
                 </p>
               </div>
               <div className="stat-card">
+                <p className="stat-label">Dashes</p>
+                <p className="stat-value">{shotsLeftDashes !== null ? shotsLeftDashes : '...'}</p>
+                {shotsLeftDashes !== null && shotsLeftDashes > 0 && (
+                  <span className="shots-left-dashes" aria-label={`${shotsLeftDashes} shots left dashes`}>
+                    {Array.from({ length: shotsLeftDashes }).map((_, index) => (
+                      <span key={index} className="shots-left-dash" />
+                    ))}
+                  </span>
+                )}
+              </div>
+              <div className="stat-card">
                 <p className="stat-label">Shots Taken Today</p>
                 <p className="stat-value">{shotsTakenToday !== null ? shotsTakenToday : '...'}</p>
               </div>
@@ -384,6 +411,13 @@ const Modal: React.FC<ModalProps> = ({ name, isOpen, onClose, playerId }) => {
             </div>
             <div className="actions">
               <button className={isDouble ? 'selected' : ''} onClick={() => setIsDouble(!isDouble)}>Double</button>
+              <button
+                className={useDash ? 'selected' : ''}
+                onClick={() => setUseDash((prev) => !prev)}
+                disabled={!shotsLeftDashes}
+              >
+                Use Dash
+              </button>
             </div>
             <button className="submit-button" onClick={handleSubmit}>Submit</button>
           </div>

--- a/src/components/Modal/modal.css
+++ b/src/components/Modal/modal.css
@@ -110,6 +110,20 @@
   letter-spacing: 0.5px;
 }
 
+.shots-left-dashes {
+  display: flex;
+  gap: 6px;
+  margin-top: 6px;
+}
+
+.shots-left-dash {
+  width: 20px;
+  height: 5px;
+  border-radius: 999px;
+  background-color: #52606d;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
+}
+
 /* General button styles */
 .modal-content button {
   background-color: #f0f0f0;
@@ -123,15 +137,15 @@
 }
 
 .submit-button {
-  background-color: #28a745;
-  border-color: #218838;
+  background-color: #f97316;
+  border-color: #ea580c;
   color: #ffffff;
   font-weight: 600;
 }
 
 .submit-button:hover {
-  background-color: #218838;
-  border-color: #1e7e34;
+  background-color: #ea580c;
+  border-color: #c2410c;
 }
 .moneyball-indicator {
   display: flex;
@@ -160,6 +174,12 @@
 
 .modal-content button.selected:hover {
   box-shadow: 0 6px 12px rgba(0, 0, 0, 0.3);
+}
+
+.modal-content button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+  box-shadow: none;
 }
 
 /* Moneyball button - base styling */
@@ -273,7 +293,7 @@
 }
 
 .actions button {
-  width: 100%;
+  flex: 1;
   padding: 20px 0;
   font-size: 1.2rem;
   font-weight: 700;
@@ -283,16 +303,16 @@
 .submit-button {
   align-self: center;
   padding: 18px 40px;
-  background-color: #22c55e;
+  background-color: #f97316;
   color: #ffffff;
-  border: 2px solid #15803d;
+  border: 2px solid #ea580c;
   font-size: 1.15rem;
   font-weight: 700;
   min-width: 180px;
 }
 
 .submit-button:hover {
-  background-color: #16a34a;
+  background-color: #ea580c;
   color: #ffffff;
 }
 


### PR DESCRIPTION
### Motivation
- Surface the same "dash" (shots_left_dashes) count shown on the Standings page inside the player modal so users can see how many dashes remain. 
- Allow an operator to opt to expend one dash when submitting a shot so dashes can be spent from the modal. 
- Make the shot submit control more visually distinct so users can easily identify and press it.

### Description
- Added `shotsLeftDashes` and `useDash` state to the modal and fetch `shots_left_dashes` from `player_instance` via the existing `fetchPlayerInstanceAndTier` flow.  
- Rendered a visual dash indicator in the modal and a `Use Dash` toggle button that is disabled when no dashes remain.  
- On submit the player instance update now writes back `shots_left_dashes` (decremented when `Use Dash` is selected) and existing `shots_left`/`score` updates remain unchanged.  
- Updated `modal.css` to restyle the submit button color, add dash visuals, and provide disabled/selected button styles for the new toggle.

### Testing
- Started the development server with `npm run dev` and the app compiled and served the Admin page (with a Google font fetch warning but fallback font used). (succeeded)
- Ran an automated Playwright screenshot script to navigate to `/Admin` and capture the modal view which produced an artifact screenshot. (succeeded)
- Verified the code compiled after the changes (Next.js build/compile step completed). (succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695afc4e5a00832ca0a7031f52bd82a9)