### PR TITLE
Update player modal submit styling and add projected points display

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -271,6 +271,17 @@ const Modal: React.FC<ModalProps> = ({ name, isOpen, onClose, playerId }) => {
     }
   }, [shotsLeftDashes]);
 
+  const projectedPoints = useMemo(() => {
+    if (points === null) return null;
+
+    let finalPoints = points;
+
+    if (isMoneyball) finalPoints *= 2;
+    if (isDouble) finalPoints *= 2;
+
+    return finalPoints;
+  }, [points, isMoneyball, isDouble]);
+
   /**
    * Handles the submission of the shot and updates player data in the database.
    */
@@ -419,7 +430,13 @@ const Modal: React.FC<ModalProps> = ({ name, isOpen, onClose, playerId }) => {
                 Use Dash
               </button>
             </div>
-            <button className="submit-button" onClick={handleSubmit}>Submit</button>
+            <div className="submit-row">
+              <button className="submit-button" onClick={handleSubmit}>Submit</button>
+              <div className="projected-points" aria-live="polite">
+                <span className="projected-label">Projected Points</span>
+                <span className="projected-value">{projectedPoints ?? '--'}</span>
+              </div>
+            </div>
           </div>
 
           <div className="rules-section">

--- a/src/components/Modal/modal.css
+++ b/src/components/Modal/modal.css
@@ -137,15 +137,15 @@
 }
 
 .submit-button {
-  background-color: #f97316;
-  border-color: #ea580c;
+  background-color: #3b82f6;
+  border-color: #2563eb;
   color: #ffffff;
   font-weight: 600;
 }
 
 .submit-button:hover {
-  background-color: #ea580c;
-  border-color: #c2410c;
+  background-color: #2563eb;
+  border-color: #1d4ed8;
 }
 .moneyball-indicator {
   display: flex;
@@ -300,20 +300,52 @@
   border-width: 2px;
 }
 
+.submit-row {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  width: 100%;
+}
+
 .submit-button {
   align-self: center;
   padding: 18px 40px;
-  background-color: #f97316;
+  background-color: #3b82f6;
   color: #ffffff;
-  border: 2px solid #ea580c;
+  border: 2px solid #2563eb;
   font-size: 1.15rem;
   font-weight: 700;
   min-width: 180px;
 }
 
 .submit-button:hover {
-  background-color: #ea580c;
+  background-color: #2563eb;
   color: #ffffff;
+}
+
+.projected-points {
+  margin-left: auto;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  padding: 10px 14px;
+  min-width: 160px;
+  box-shadow: 0 4px 10px rgba(15, 23, 42, 0.08);
+}
+
+.projected-label {
+  font-size: 0.9rem;
+  color: #64748b;
+  font-weight: 600;
+}
+
+.projected-value {
+  font-size: 1.4rem;
+  font-weight: 800;
+  color: #0f172a;
 }
 
 .waiver-disclaimer {


### PR DESCRIPTION
### Motivation
- Improve the visibility of the modal submit action by switching the default color to a standard blue primary style.  
- Give immediate feedback to players by showing projected point value next to the submit button as they change selections.  

### Description
- Changed submit button styling in `src/components/Modal/modal.css` to a blue primary palette and added a `.submit-row` layout.  
- Added a `projectedPoints` `useMemo` in `src/components/Modal/Modal.tsx` that computes the projected points including `isMoneyball` and `isDouble` multipliers.  
- Inserted a right-aligned projected points panel next to the `Submit` button (`.projected-points`) with `aria-live="polite"` for screen-reader updates.  
- Kept existing submit logic intact; the displayed projection uses the same multiplier rules applied at submit.  

### Testing
- Started the dev server with `npm run dev` and Next compiled successfully (Google Fonts fetch produced a warning and fallback font was used).  
- Ran an automated Playwright script to capture a UI screenshot and the script completed and produced `player-modal.png`.  
- No unit tests were added or modified for this UI-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695aff475284832c91c85f4070276473)