### PR TITLE
Moneyball cadence every 10th shot; rename modal label to Point Preview

### DIFF
--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -261,7 +261,12 @@ const Modal: React.FC<ModalProps> = ({ name, isOpen, onClose, playerId }) => {
    * Automatically set the Moneyball flag based on specific shot counts.
    */
   useEffect(() => {
-    const isMoneyballShot = [1, 11, 21, 31, 41].includes(shotsLeft || 0);
+    if (shotsLeft === null) {
+      setIsMoneyball(false);
+      return;
+    }
+
+    const isMoneyballShot = shotsLeft % 10 === 1;
     setIsMoneyball(isMoneyballShot);
   }, [shotsLeft]);
 
@@ -433,7 +438,7 @@ const Modal: React.FC<ModalProps> = ({ name, isOpen, onClose, playerId }) => {
             <div className="submit-row">
               <button className="submit-button" onClick={handleSubmit}>Submit</button>
               <div className="projected-points" aria-live="polite">
-                <span className="projected-label">Projected Points</span>
+                <span className="projected-label">Point Preview</span>
                 <span className="projected-value">{projectedPoints ?? '--'}</span>
               </div>
             </div>


### PR DESCRIPTION
### Motivation
- Ensure Moneyball behavior triggers on every 10th remaining shot (e.g. 21st, 31st, 41st, 51st, 61st, 71st, 81st) instead of a fixed list that stopped at 41. 
- Surface the projected score more clearly by updating the label to match product copy.
- Make sure the modal UI highlights Moneyball shots and continues to play the correct notification/shot sounds.

### Description
- Change Moneyball detection to use modulo logic by setting `isMoneyball` when `shotsLeft % 10 === 1` and handle `null` `shotsLeft` to avoid false positives. (File changed: `src/components/Modal/Modal.tsx`.)
- Rename the `Projected Points` label to `Point Preview` in the modal and keep the projected value behavior unchanged. 
- Leave existing submit button styling on the `submit-button` class (blue background is already applied in CSS).

### Testing
- Started the dev server with `npm run dev` and the app compiled and served, with a Google Fonts fetch warning but fallback fonts used (server ready). (Succeeded)
- Ran a Playwright screenshot script to render the app and capture the modal page artifact for visual verification. (Succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b049c9ecc832c98f1a2e3aa4074eb)