### PR TITLE
Improve player modal styling and touch targets

### DIFF
--- a/src/components/Modal/modal.css
+++ b/src/components/Modal/modal.css
@@ -32,7 +32,7 @@
 /* Modal Content */
 .modal-content {
   position: relative; /* To position the X button */
-  background: white;
+  background: linear-gradient(180deg, #ffffff 0%, #f8fafc 100%);
   padding: 24px 32px 32px;
   border-radius: 16px;
   text-align: center;
@@ -76,6 +76,11 @@
   width: 100%;
   max-width: 420px;
   text-align: left;
+  background: #ffffff;
+  border: 1px solid #e2e8f0;
+  border-radius: 16px;
+  padding: 16px;
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.08);
 }
 
 .stats-overview {
@@ -86,11 +91,11 @@
 }
 
 .stat-card {
-  background: linear-gradient(135deg, #f8fafc 0%, #edf2f7 100%);
-  border: 1px solid #e5e7eb;
+  background: linear-gradient(135deg, #ffffff 0%, #f8fafc 100%);
+  border: 1px solid #e2e8f0;
   border-radius: 12px;
   padding: 12px 14px;
-  box-shadow: 0 6px 14px rgba(0, 0, 0, 0.06);
+  box-shadow: 0 6px 14px rgba(15, 23, 42, 0.06);
   display: flex;
   flex-direction: column;
   gap: 4px;
@@ -126,26 +131,27 @@
 
 /* General button styles */
 .modal-content button {
-  background-color: #f0f0f0;
-  border: 1px solid #ccc;
+  background-color: #f8fafc;
+  border: 1px solid #cbd5f5;
   padding: 16px 28px;
   cursor: pointer;
   transition: box-shadow 0.2s ease-in-out, background-color 0.2s ease-in-out;
   font-size: 1.15rem;
   border-radius: 12px;
   min-width: 72px;
+  min-height: 56px;
 }
 
 .submit-button {
-  background-color: #3b82f6;
-  border-color: #2563eb;
+  background-color: #1d4ed8;
+  border-color: #1e40af;
   color: #ffffff;
   font-weight: 600;
 }
 
 .submit-button:hover {
-  background-color: #2563eb;
-  border-color: #1d4ed8;
+  background-color: #1e40af;
+  border-color: #1e3a8a;
 }
 .moneyball-indicator {
   display: flex;
@@ -163,13 +169,14 @@
 }
 /* Hover for all buttons */
 .modal-content button:hover {
-  background-color: #e0e0e0;
+  background-color: #e2e8f0;
 }
 
 /* Selected state for buttons */
 .modal-content button.selected {
-  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
-  background-color: #d4edda;
+  box-shadow: 0 6px 12px rgba(15, 23, 42, 0.18);
+  background-color: #dbeafe;
+  border-color: #93c5fd;
 }
 
 .modal-content button.selected:hover {
@@ -239,7 +246,7 @@
   top: 0;
   align-self: flex-end;
   background: #ffffff;
-  border: 1px solid #ccc;
+  border: 1px solid #cbd5e1;
   border-radius: 50%;
   width: 44px;
   height: 44px;
@@ -248,8 +255,8 @@
   justify-content: center;
   font-size: 20px;
   cursor: pointer;
-  color: black;
-  box-shadow: 0 2px 6px rgba(0, 0, 0, 0.12);
+  color: #0f172a;
+  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.14);
   margin-left: auto;
 }
 
@@ -298,6 +305,7 @@
   font-size: 1.2rem;
   font-weight: 700;
   border-width: 2px;
+  min-height: 64px;
 }
 
 .submit-row {
@@ -305,21 +313,25 @@
   align-items: center;
   gap: 16px;
   width: 100%;
+  flex-wrap: wrap;
 }
 
 .submit-button {
   align-self: center;
   padding: 18px 40px;
-  background-color: #3b82f6;
+  background-color: #1d4ed8;
   color: #ffffff;
-  border: 2px solid #2563eb;
+  border: 2px solid #1e40af;
   font-size: 1.15rem;
   font-weight: 700;
   min-width: 180px;
+  min-height: 56px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
 }
 
 .submit-button:hover {
-  background-color: #2563eb;
+  background-color: #1e40af;
   color: #ffffff;
 }
 


### PR DESCRIPTION
### Motivation
- Make the player modal more aesthetic while preserving all existing functionality. 
- Ensure the submit button is legible before being clicked and improve overall contrast. 
- Keep the existing look of the current/next shot rules while refining the rest of the layout. 
- Improve touch targets so controls are easier to use on touch screens.

### Description
- Updated `src/components/Modal/modal.css` to apply a soft gradient background to the modal and refined shadows and border radii for a cleaner card-like layout. 
- Restyled the score section (`.score-section`) with its own white background, border, padding and elevated box-shadow to separate it visually. 
- Increased button touch targets and spacing by adding `min-height` to general buttons, `.points` and `.actions` buttons, and made selected states and hover backgrounds higher-contrast. 
- Adjusted the submit button colors, border, typography (uppercase + letter-spacing) and sizing to improve legibility and prominence (`.submit-button` now uses a darker blue and larger min-height).

### Testing
- Started the app with `npm run dev`, which compiled and served the app but logged a Google Fonts fetch warning that fell back to the local font (compilation succeeded). 
- Executed a headless Playwright script to open the app and capture a screenshot of the modal, which completed and produced an artifact. 
- No unit or integration tests were modified or required for this purely visual change. 
- Manual QA was not included in automated test runs in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b0720ab90832cb8ceae5b8c3ecaa1)