### PR TITLE
Fix submit button text color

### DIFF
--- a/src/components/Modal/modal.css
+++ b/src/components/Modal/modal.css
@@ -145,7 +145,7 @@
 .submit-button {
   background-color: #1d4ed8;
   border-color: #1e40af;
-  color: #ffffff;
+  color: #000000;
   font-weight: 600;
 }
 


### PR DESCRIPTION
### Motivation
- The submit button text in the player modal was white on a blue background and not readable. 
- Improve contrast/readability by switching the label color to black. 

### Description
- Changed the `.submit-button` text color in `src/components/Modal/modal.css` from `#ffffff` to `#000000`.
- Kept existing background and hover styles intact to preserve button visuals.
- Staged and committed the change with the message `Fix submit button text color`.

### Testing
- Started the development server with `npm run dev` and the app compiled successfully with a Google Fonts fetch warning but fell back to a local font.
- Captured a UI screenshot using a Playwright script which completed and produced `artifacts/player-modal-submit.png`.
- No unit or integration test suites were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b095b7fdc832ca3b10caac41da019)