### PR TITLE
Add team-colored double borders to standings cards

### DIFF
--- a/src/app/Standings/StandingsPage.module.css
+++ b/src/app/Standings/StandingsPage.module.css
@@ -178,11 +178,32 @@
 .team {
   display: flex;
   flex-direction: column;
-  border: 1px solid #ddd;
+  border: 2px solid var(--team-border-primary, #ddd);
   padding: 15px;
   border-radius: 10px;
   background-color: #fafafa;
   box-sizing: border-box;
+  box-shadow: 0 0 0 2px var(--team-border-secondary, #ddd);
+}
+
+.teamNightmares {
+  --team-border-primary: #f4c542;
+  --team-border-secondary: #7a1e2c;
+}
+
+.teamDirewolves {
+  --team-border-primary: #f26a21;
+  --team-border-secondary: #0b1f3a;
+}
+
+.teamMonstars {
+  --team-border-primary: #3fae2a;
+  --team-border-secondary: #111111;
+}
+
+.teamSpartans {
+  --team-border-primary: #4b5320;
+  --team-border-secondary: #6b8e23;
 }
 
 .teamStatsGrid {

--- a/src/app/Standings/page.tsx
+++ b/src/app/Standings/page.tsx
@@ -53,6 +53,13 @@ const teamLogoMap: Record<string, StaticImageData> = {
   Spartans: spartansLogo,
 };
 
+const teamBorderClassMap: Record<string, string> = {
+  Direwolves: styles.teamDirewolves,
+  Monstars: styles.teamMonstars,
+  Nightmares: styles.teamNightmares,
+  Spartans: styles.teamSpartans,
+};
+
 
 
 // Function to calculate the current streak of consecutive made shots
@@ -510,7 +517,10 @@ const StandingsPage: React.FC = () => {
         <div className={styles.container}>
           <div className={styles.teams}>
             {teams.map((team, index) => (
-              <div key={index} className={styles.team}>
+              <div
+                key={index}
+                className={`${styles.team} ${teamBorderClassMap[team.team_name] ?? ''}`}
+              >
                 {/* Team Title */}
                 <div className={styles.teamHeader}>
                   {teamLogoMap[team.team_name] && (


### PR DESCRIPTION
### Motivation
- Give the standings page more team identity and comradery by adding a double-line colored border around each team card using the teams' colors.
- Use each team's logo colors for the effect: Nightmares (yellow / maroon), Direwolves (orange / navy), Monstars (green / black), and Spartans (army green / olive).

### Description
- Added CSS variables and team-specific classes to `StandingsPage.module.css` to expose `--team-border-primary` and `--team-border-secondary` and produce a double-line effect using `border` and `box-shadow`.
- Introduced `.teamNightmares`, `.teamDirewolves`, `.teamMonstars`, and `.teamSpartans` classes with the requested color values.
- Mapped team names to the new CSS classes in `page.tsx` via `teamBorderClassMap` and applied the class to each team card with `className={`${styles.team} ${teamBorderClassMap[team.team_name] ?? ''}`}`.
- Kept existing layout and statistics logic intact and provided a safe fallback when a team mapping is not present.

### Testing
- Started the dev server with `npm run dev` and the `/Standings` page compiled and served, although Google font fetches logged warnings and a fallback font was used.
- Ran a Playwright script to load `http://127.0.0.1:3000/Standings` and captured a screenshot of the updated standings page, which completed successfully and produced an artifact.
- No unit or lint test suite was run as part of this change.
- Changes were committed to the repository and include the two modified files `src/app/Standings/StandingsPage.module.css` and `src/app/Standings/page.tsx`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695b1a71b8f4832cb0eb5a9fbefec572)