### PR TITLE
Adjust standings team logos and remove duplicate team name text

### DIFF
--- a/src/app/Standings/StandingsPage.module.css
+++ b/src/app/Standings/StandingsPage.module.css
@@ -243,25 +243,16 @@
   color: #264653;
 }
 
-/* Team title */
-.teamTitle {
-  text-align: center;
-  font-size: 2rem;
-  font-weight: bold;
-  margin: 0;
-}
-
 .teamHeader {
   display: flex;
   align-items: center;
   justify-content: center;
-  gap: 16px;
   margin-bottom: 14px;
 }
 
 .teamLogo {
   width: auto;
-  height: 168px;
+  height: 202px;
   object-fit: contain;
 }
 

--- a/src/app/Standings/page.tsx
+++ b/src/app/Standings/page.tsx
@@ -53,6 +53,13 @@ const teamLogoMap: Record<string, StaticImageData> = {
   Spartans: spartansLogo,
 };
 
+const teamLogoSizeMap: Record<string, number> = {
+  Direwolves: 202,
+  Monstars: 202,
+  Nightmares: 202,
+  Spartans: 202,
+};
+
 const teamBorderClassMap: Record<string, string> = {
   Direwolves: styles.teamDirewolves,
   Monstars: styles.teamMonstars,
@@ -528,12 +535,11 @@ const StandingsPage: React.FC = () => {
                       className={styles.teamLogo}
                       src={teamLogoMap[team.team_name]}
                       alt={`${team.team_name} logo`}
-                      width={168}
-                      height={168}
-                      sizes="168px"
+                      width={teamLogoSizeMap[team.team_name] ?? 202}
+                      height={teamLogoSizeMap[team.team_name] ?? 202}
+                      sizes={`${teamLogoSizeMap[team.team_name] ?? 202}px`}
                     />
                   )}
-                  <h2 className={styles.teamTitle}>{team.team_name}</h2>
                 </div>
                 <div className={styles.teamStatsGrid}>
                   <div className={styles.statBox}>


### PR DESCRIPTION
### Motivation
- Team logos were visually inconsistent (Direwolves larger, Monstars smaller), so resize Direwolves ~20% and scale the others to match.
- The team name text rendered to the right of each logo is redundant because the logo image already contains the name, and removing it allows the logo to be centered.

### Description
- Added a `teamLogoSizeMap` and use it to set `width`, `height`, and `sizes` on the Next `Image` component in `src/app/Standings/page.tsx` so logos are sized uniformly.
- Removed the rendered `<h2 className={styles.teamTitle}>` so team names are no longer displayed beside logos.
- Updated `src/app/Standings/StandingsPage.module.css` by deleting the `.teamTitle` rule, removing the gap between header items, and increasing `.teamLogo` height from `168px` to `202px`.

### Testing
- Started the Next.js development server with `npm run dev`, and the server started successfully.
- Attempted a Playwright screenshot to verify the UI, but Chromium crashed and the screenshot step failed.
- No automated unit or integration tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bacc60260832c81434705a821abc4)