### PR TITLE
Increase Monstars logo size on standings page

### DIFF
--- a/src/app/Standings/page.tsx
+++ b/src/app/Standings/page.tsx
@@ -55,7 +55,7 @@ const teamLogoMap: Record<string, StaticImageData> = {
 
 const teamLogoSizeMap: Record<string, number> = {
   Direwolves: 202,
-  Monstars: 202,
+  Monstars: 242,
   Nightmares: 202,
   Spartans: 202,
 };


### PR DESCRIPTION
### Motivation
- Make the Monstars logo render size ~20% larger so it visually matches the other team logos on the standings page.
- The Monstars image appeared smaller than the other team logos when rendered at the same size.

### Description
- Updated `teamLogoSizeMap` in `src/app/Standings/page.tsx` to change `Monstars` from `202` to `242`.
- No other UI, CSS, or asset changes were made.

### Testing
- Started the dev server with `npm run dev` and the `/Standings` page compiled successfully and returned HTTP 200.
- Captured a screenshot via Playwright which produced `artifacts/standings-monstars-logo.png` successfully.
- Google Fonts fetch for `Inter` failed during build and a fallback font was used, but compilation still succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695bae4cdadc832ca3ae307615443d18)