### PR TITLE
Adjust score modal for compact landscape

### DIFF
--- a/src/components/Modal/modal.css
+++ b/src/components/Modal/modal.css
@@ -457,3 +457,77 @@
   color: #555;
   font-weight: 500;
 }
+
+/* =========================
+   Compact Landscape Layouts
+========================= */
+@media (max-height: 820px) {
+  .modal-overlay {
+    align-items: flex-start;
+    padding: 16px;
+  }
+
+  .modal-content {
+    padding: 16px 20px 20px;
+    max-height: 92vh;
+    gap: 8px;
+    font-size: 1rem;
+  }
+
+  .modal-title {
+    margin: 0 auto 4px;
+    font-size: 1.5rem;
+  }
+
+  .modal-body {
+    gap: 20px;
+  }
+
+  .score-section {
+    padding: 12px;
+    gap: 10px;
+  }
+
+  .stat-card {
+    padding: 10px 12px;
+  }
+
+  .stat-value {
+    font-size: 1.3rem;
+  }
+
+  .points button {
+    padding: 14px 20px;
+    font-size: 1.1rem;
+    min-height: 56px;
+  }
+
+  .actions button {
+    padding: 14px 0;
+    font-size: 1.05rem;
+    min-height: 52px;
+  }
+
+  .modal-content button.submit-button {
+    padding: 14px 28px;
+    font-size: 1.05rem;
+    min-height: 52px;
+  }
+
+  .projected-points {
+    padding: 8px 12px;
+    min-width: 140px;
+  }
+
+  .rules-section {
+    gap: 12px;
+  }
+
+  .rule-card {
+    padding: 12px 14px;
+  }
+
+  .rule-card li {
+    padding: 6px 8px;
+  }
+}


### PR DESCRIPTION
### Motivation
- Players on short landscape displays (e.g. Surface Pro held horizontally) must scroll to reach Submit and view the point preview, so reduce the modal's vertical footprint to avoid scrolling.
- Keep the existing visual hierarchy while making controls and sections more compact on low-height viewports.

### Description
- Added a compact landscape media query `@media (max-height: 820px)` to `src/components/Modal/modal.css` to target short/landscape viewports.
- Reduced modal paddings, gaps, font sizes, and button heights, and adjusted `max-height` and overlay alignment so the submit row and point preview fit without scrolling.
- Tuned spacing for `.modal-title`, `.modal-body`, `.score-section`, `.points`, `.actions`, `.projected-points`, and `.rules-section` for a tighter layout.

### Testing
- Started the dev server with `npm run dev -- --hostname 0.0.0.0 --port 3000`, which compiled the app successfully but emitted a Google Fonts download warning for `Inter` (font fallback used). (succeeded)
- Ran an automated Playwright script to open `/Admin` at `http://127.0.0.1:3000/Admin` and capture a screenshot of the modal to verify layout in a 1366x768 viewport, which completed and produced an artifact. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695e8b8d8bcc832c802c6b1304d6d883)