### PR TITLE
Add moneyball badge to standings when shots left is a moneyball

### DIFF
--- a/src/app/Standings/StandingsPage.module.css
+++ b/src/app/Standings/StandingsPage.module.css
@@ -174,6 +174,11 @@
   font-size: 18px;
 }
 
+.moneyballIcon {
+  margin-left: 6px;
+  font-size: 18px;
+}
+
 /* Individual team card */
 .team {
   display: flex;

--- a/src/app/Standings/page.tsx
+++ b/src/app/Standings/page.tsx
@@ -576,6 +576,9 @@ const StandingsPage: React.FC = () => {
                         {player.name === 'A. Begy' && (
                           <span className={styles.crownIcon}>👑</span>
                         )}
+                        {player.shots_left % 10 === 1 && (
+                          <span className={styles.moneyballIcon}>💲</span>
+                        )}
                         {/* Fire Icon: 3+ Consecutive Makes */}
                         {player.shots_made_in_row >= 3 && (
                           <span className={styles.fireIcon}>


### PR DESCRIPTION
### Motivation
- Provide a visual indicator in the standings when a player is on a moneyball shot (e.g. Shots Left = 51, 61) so it appears alongside existing badges like crown, fire, and snowflake.

### Description
- Insert a moneyball badge next to player names in the standings view when `player.shots_left % 10 === 1` by adding a `💲` span in `src/app/Standings/page.tsx` near the other icon spans.
- Add `.moneyballIcon` CSS in `src/app/Standings/StandingsPage.module.css` sized and spaced to match the existing crown/fire/snowflake icons.

### Testing
- Started the dev server with `npm run dev` and compiled the `/Standings` page successfully (served `GET /Standings 200`).
- Captured a screenshot of the Standings page using Playwright to verify the icon placement (`artifacts/standings-moneyball.png`).
- Note: during dev startup the `Inter` Google font fetch failed and Next used a fallback font, but the page still compiled and the UI verification succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985caa61228832cb55ee13faaf307dd)