### PR TITLE
Add monthly shot limit admin control and modal override prompt

### DIFF
--- a/src/components/AdjustMonthlyShotLimit.module.css
+++ b/src/components/AdjustMonthlyShotLimit.module.css
@@ -1,0 +1,57 @@
+.adjustMonthlyShotLimit {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  background: #ffffff;
+  border-radius: 16px;
+  padding: 16px;
+  border: 1px solid #e2e8f0;
+  box-shadow: 0 10px 24px rgba(15, 23, 42, 0.08);
+  max-width: 520px;
+}
+
+.header {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: #0f172a;
+}
+
+.helperText {
+  margin: 0;
+  color: #64748b;
+}
+
+.formRow {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.limitInput {
+  width: 140px;
+  padding: 10px 12px;
+  border-radius: 10px;
+  border: 1px solid #cbd5e1;
+  font-size: 1rem;
+}
+
+.actions {
+  display: flex;
+  gap: 12px;
+}
+
+.saveButton {
+  background: #1d4ed8;
+  color: #ffffff;
+  border: none;
+  border-radius: 10px;
+  padding: 10px 18px;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.saveButton:hover {
+  background: #1e40af;
+}

--- a/src/components/AdjustMonthlyShotLimit.tsx
+++ b/src/components/AdjustMonthlyShotLimit.tsx
@@ -1,0 +1,105 @@
+/**
+ * AdjustMonthlyShotLimit Component
+ *
+ * Allows administrators to view and update the monthly shot limit for the active season.
+ * - Fetches the active season limit from Supabase.
+ * - Saves changes to the `monthly_shot_limit` column on the active season.
+ */
+
+import React, { useCallback, useEffect, useState } from 'react';
+import { supabase } from '@/supabaseClient';
+import styles from './AdjustMonthlyShotLimit.module.css';
+
+interface AdjustMonthlyShotLimitProps {
+  isOpen: boolean;
+}
+
+const DEFAULT_MONTHLY_SHOT_LIMIT = 40;
+
+const AdjustMonthlyShotLimit: React.FC<AdjustMonthlyShotLimitProps> = ({ isOpen }) => {
+  const [seasonId, setSeasonId] = useState<number | null>(null);
+  const [limit, setLimit] = useState<number>(DEFAULT_MONTHLY_SHOT_LIMIT);
+  const [saving, setSaving] = useState(false);
+
+  const fetchLimit = useCallback(async () => {
+    try {
+      const { data, error } = await supabase
+        .from('seasons')
+        .select('season_id, monthly_shot_limit')
+        .is('end_date', null)
+        .single();
+
+      if (error || !data) {
+        console.error('Error fetching monthly shot limit:', error);
+        return;
+      }
+
+      setSeasonId(data.season_id);
+      setLimit(Number(data.monthly_shot_limit) || DEFAULT_MONTHLY_SHOT_LIMIT);
+    } catch (error) {
+      console.error('Unexpected error fetching monthly shot limit:', error);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    fetchLimit();
+
+    const seasonChannel = supabase
+      .channel('monthly-shot-limit-updates')
+      .on('postgres_changes', { event: 'UPDATE', schema: 'public', table: 'seasons' }, fetchLimit)
+      .subscribe();
+
+    return () => {
+      supabase.removeChannel(seasonChannel);
+    };
+  }, [fetchLimit, isOpen]);
+
+  const handleSave = async () => {
+    if (!seasonId) return;
+
+    setSaving(true);
+    try {
+      const { error } = await supabase
+        .from('seasons')
+        .update({ monthly_shot_limit: limit })
+        .eq('season_id', seasonId);
+
+      if (error) {
+        console.error('Error updating monthly shot limit:', error);
+      }
+    } catch (error) {
+      console.error('Unexpected error updating monthly shot limit:', error);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className={styles.adjustMonthlyShotLimit}>
+      <h2 className={styles.header}>Monthly Shot Limit</h2>
+      <p className={styles.helperText}>
+        Update the maximum number of shots each player can take per month before an override prompt appears.
+      </p>
+      <div className={styles.formRow}>
+        <label htmlFor="monthlyShotLimit">Monthly limit</label>
+        <input
+          id="monthlyShotLimit"
+          className={styles.limitInput}
+          type="number"
+          min={0}
+          value={limit}
+          onChange={(event) => setLimit(Number(event.target.value))}
+        />
+      </div>
+      <div className={styles.actions}>
+        <button className={styles.saveButton} onClick={handleSave} disabled={saving}>
+          {saving ? 'Saving...' : 'Save'}
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default AdjustMonthlyShotLimit;

--- a/src/components/CurrentSeason/CurrentSeasonModal.tsx
+++ b/src/components/CurrentSeason/CurrentSeasonModal.tsx
@@ -7,6 +7,7 @@ import AdjustScores from '../AdjustScores';
 import AdjustTiers from '../AdjustTier';
 import AddPlayers from '../AddPlayers';
 import AdjustRules from '../AdjustRules';
+import AdjustMonthlyShotLimit from '../AdjustMonthlyShotLimit';
 
 // Type definition for the component's props
 interface CurrentSeasonModalProps {
@@ -52,6 +53,7 @@ const CurrentSeasonModal: React.FC<CurrentSeasonModalProps> = ({ isOpen, onClose
 
   const controls = [
     { key: 'Adjust Shots', label: 'Adjust Shots', description: 'Update shot attempts and completions.' },
+    { key: 'Monthly Shot Limit', label: 'Monthly Shot Limit', description: 'Update the monthly shot cap for players.' },
     { key: 'Shots Left Dashes', label: 'Shots Left Dashes', description: 'Assign up to two dashes under shots left.' },
     { key: 'Teams', label: 'Team/Player Edit', description: 'Manage teams and player rosters.' },
     { key: 'Adjust Scores', label: 'Adjust Scores', description: 'Modify scores and results.' },
@@ -157,6 +159,7 @@ const CurrentSeasonModal: React.FC<CurrentSeasonModalProps> = ({ isOpen, onClose
         <div className={styles.contentWrapper}>
           <div className={styles.content}>
             {activeTab === 'Adjust Shots' && <AdjustShots isOpen={isOpen} />}
+            {activeTab === 'Monthly Shot Limit' && <AdjustMonthlyShotLimit isOpen={isOpen} />}
             {activeTab === 'Shots Left Dashes' && <AdjustShotsDashes isOpen={isOpen} />}
             {activeTab === 'Teams' && <AdjustTeams isOpen={isOpen} />}
             {activeTab === 'Adjust Scores' && <AdjustScores isOpen={isOpen} />}

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -18,6 +18,7 @@ interface ModalProps {
  * and handling specific shot scenarios like Moneyball or Double points.
  */
 const Modal: React.FC<ModalProps> = ({ name, isOpen, onClose, playerId }) => {
+  const defaultMonthlyShotLimit = 40;
   // State variables for managing modal interactions and player data
   const [points, setPoints] = useState<number | null>(null); // Points for the shot
   const [isMoneyball, setIsMoneyball] = useState<boolean>(false); // Tracks if the current shot is a Moneyball
@@ -29,6 +30,9 @@ const Modal: React.FC<ModalProps> = ({ name, isOpen, onClose, playerId }) => {
   const [shotsLeftDashes, setShotsLeftDashes] = useState<number | null>(null); // Remaining dash shots
   const [shotsTakenToday, setShotsTakenToday] = useState<number | null>(null); // Shots taken in the current calendar day
   const [todaysScore, setTodaysScore] = useState<number | null>(null); // Points earned today
+  const [monthlyShotLimit, setMonthlyShotLimit] = useState<number | null>(null); // Monthly shot limit for the season
+  const [monthlyShotsTaken, setMonthlyShotsTaken] = useState<number | null>(null); // Shots taken in the current month
+  const [monthlyShotsLeft, setMonthlyShotsLeft] = useState<number | null>(null); // Remaining monthly shots
   const [useDash, setUseDash] = useState<boolean>(false); // Spend a dash on submit
   const sound = new Howl({ src: ['/sounds/shot.mp3'] }); // Sound effect for shots
   const shotSound = useMemo(() => new Howl({ src: ['/sounds/onfire.mp3'] }), []);
@@ -70,6 +74,9 @@ const Modal: React.FC<ModalProps> = ({ name, isOpen, onClose, playerId }) => {
     setShotsLeftDashes(null);
     setShotsTakenToday(null);
     setTodaysScore(null);
+    setMonthlyShotLimit(null);
+    setMonthlyShotsTaken(null);
+    setMonthlyShotsLeft(null);
     setUseDash(false);
   };
   const calculateShotsMadeInRow = async (playerInstanceId: number) => {
@@ -176,6 +183,39 @@ const Modal: React.FC<ModalProps> = ({ name, isOpen, onClose, playerId }) => {
     }
   }, []);
 
+  const fetchMonthlyShotsTaken = useCallback(async (instanceId: number, limit: number) => {
+    try {
+      const startOfMonth = new Date();
+      startOfMonth.setDate(1);
+      startOfMonth.setHours(0, 0, 0, 0);
+
+      const startOfNextMonth = new Date(startOfMonth);
+      startOfNextMonth.setMonth(startOfNextMonth.getMonth() + 1);
+
+      const { data, error } = await supabase
+        .from('shots')
+        .select('shot_id')
+        .eq('instance_id', instanceId)
+        .gte('shot_date', startOfMonth.toISOString())
+        .lt('shot_date', startOfNextMonth.toISOString());
+
+      if (error) {
+        console.error("Error fetching this month's shots:", error);
+        setMonthlyShotsTaken(null);
+        setMonthlyShotsLeft(null);
+        return;
+      }
+
+      const totalShotsThisMonth = data?.length ?? 0;
+      setMonthlyShotsTaken(totalShotsThisMonth);
+      setMonthlyShotsLeft(limit - totalShotsThisMonth);
+    } catch (error) {
+      console.error("Unexpected error fetching this month's shots:", error);
+      setMonthlyShotsTaken(null);
+      setMonthlyShotsLeft(null);
+    }
+  }, []);
+
   /**
    * Handles closing the modal and resetting its state.
    */
@@ -192,7 +232,7 @@ const Modal: React.FC<ModalProps> = ({ name, isOpen, onClose, playerId }) => {
       // Fetch the current season
       const { data: currentSeason, error: seasonError } = await supabase
         .from('seasons')
-        .select('season_id')
+        .select('season_id, monthly_shot_limit')
         .is('end_date', null)
         .single();
 
@@ -200,6 +240,9 @@ const Modal: React.FC<ModalProps> = ({ name, isOpen, onClose, playerId }) => {
         console.error('Error fetching current season:', seasonError);
         return;
       }
+
+      const seasonMonthlyLimit = Number(currentSeason.monthly_shot_limit) || defaultMonthlyShotLimit;
+      setMonthlyShotLimit(seasonMonthlyLimit);
 
       // Fetch player instance details
       const { data: playerInstance, error: instanceError } = await supabase
@@ -220,6 +263,7 @@ const Modal: React.FC<ModalProps> = ({ name, isOpen, onClose, playerId }) => {
       setShotsLeft(playerInstance.shots_left);
       setShotsLeftDashes(playerInstance.shots_left_dashes ?? 0);
       fetchShotsTakenToday(playerInstance.player_instance_id);
+      fetchMonthlyShotsTaken(playerInstance.player_instance_id, seasonMonthlyLimit);
 
       // Fetch the player's tier ID
       const { data: player, error: playerError } = await supabase
@@ -237,7 +281,7 @@ const Modal: React.FC<ModalProps> = ({ name, isOpen, onClose, playerId }) => {
     } catch (error) {
       console.error('Unexpected error:', error);
     }
-  }, [fetchShotsTakenToday, playerId]);
+  }, [fetchMonthlyShotsTaken, fetchShotsTakenToday, playerId]);
 
   /**
    * Fetch data when the modal is opened and set up real-time updates for player instance changes.
@@ -256,6 +300,29 @@ const Modal: React.FC<ModalProps> = ({ name, isOpen, onClose, playerId }) => {
       supabase.removeChannel(playerInstanceChannel);
     };
   }, [isOpen, fetchPlayerInstanceAndTier]);
+
+  useEffect(() => {
+    if (!isOpen || !playerInstanceId) return;
+
+    const monthlyShotsChannel = supabase
+      .channel('monthly-shots-db-changes')
+      .on('postgres_changes', { event: '*', schema: 'public', table: 'shots' }, () => {
+        fetchMonthlyShotsTaken(playerInstanceId, monthlyShotLimit ?? defaultMonthlyShotLimit);
+      })
+      .subscribe();
+
+    const seasonLimitChannel = supabase
+      .channel('monthly-shot-limit-changes')
+      .on('postgres_changes', { event: 'UPDATE', schema: 'public', table: 'seasons' }, () => {
+        fetchPlayerInstanceAndTier();
+      })
+      .subscribe();
+
+    return () => {
+      supabase.removeChannel(monthlyShotsChannel);
+      supabase.removeChannel(seasonLimitChannel);
+    };
+  }, [fetchMonthlyShotsTaken, fetchPlayerInstanceAndTier, isOpen, monthlyShotLimit, playerInstanceId]);
 
   /**
    * Automatically set the Moneyball flag based on specific shot counts.
@@ -287,11 +354,24 @@ const Modal: React.FC<ModalProps> = ({ name, isOpen, onClose, playerId }) => {
     return finalPoints;
   }, [points, isMoneyball, isDouble]);
 
+  const monthlyShotsLeftDisplay = useMemo(() => {
+    if (monthlyShotsLeft === null) return '--';
+    return Math.max(0, monthlyShotsLeft);
+  }, [monthlyShotsLeft]);
+
   /**
    * Handles the submission of the shot and updates player data in the database.
    */
   const handleSubmit = async () => {
     if (points === null || playerInstanceId === null || tierId === null) return;
+
+    if (monthlyShotsLeft !== null && monthlyShotsLeft <= 0) {
+      const confirmOverride = window.confirm(
+        'This player has already reached their monthly shot limit. Submit this shot anyway?'
+      );
+
+      if (!confirmOverride) return;
+    }
   
     const shouldPlayNotification = (points === 1 || points === 2) && isMoneyball;
   
@@ -378,9 +458,15 @@ const Modal: React.FC<ModalProps> = ({ name, isOpen, onClose, playerId }) => {
         className={`modal-content ${isMoneyball ? 'highlight-modal-border' : ''}`}
         onClick={(e) => e.stopPropagation()}
       >
-        <button className="close-button" onClick={handleClose} aria-label="Close player modal">
-          ×
-        </button>
+        <div className="modal-header">
+          <div className="monthly-shots-left" aria-live="polite">
+            <span className="monthly-shots-label">Monthly Shots Left:</span>
+            <span className="monthly-shots-value">{monthlyShotsLeftDisplay}</span>
+          </div>
+          <button className="close-button" onClick={handleClose} aria-label="Close player modal">
+            ×
+          </button>
+        </div>
 
         <h2 className="modal-title">{name}</h2>
 

--- a/src/components/Modal/modal.css
+++ b/src/components/Modal/modal.css
@@ -32,6 +32,33 @@
   font-size: 1.1rem;
 }
 
+.modal-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.monthly-shots-left {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 12px;
+  border-radius: 999px;
+  background: #f8fafc;
+  border: 1px solid #e2e8f0;
+  box-shadow: 0 4px 10px rgba(15, 23, 42, 0.08);
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: #0f172a;
+}
+
+.monthly-shots-value {
+  font-size: 1.1rem;
+  font-weight: 800;
+  color: #1d4ed8;
+}
+
 .modal-title {
   margin: 4px auto 8px;
   font-size: 1.8rem;
@@ -258,7 +285,6 @@
 .close-button {
   position: sticky;
   top: 0;
-  align-self: flex-end;
   background: #ffffff;
   border: 1px solid #cbd5e1;
   border-radius: 50%;

--- a/src/components/NextSeason/NextSeason.tsx
+++ b/src/components/NextSeason/NextSeason.tsx
@@ -583,6 +583,7 @@ const NextSeasonModal: React.FC<NextSeasonModalProps> = ({ isOpen, onClose, onSt
         start_date: currentDate.toISOString(),
         end_date: null,
         shot_total: shotCount,
+        monthly_shot_limit: 40,
         rules: seasonRules || 'Default Rules',
         is_official: shouldRecordStats,
       })

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -39,6 +39,7 @@ export const seasonsTable = pgTable('seasons', {
   startDate: timestamp('start_date').notNull(),
   endDate: timestamp('end_date').notNull(),
   shotTotal: integer('shot_total').notNull(),
+  monthlyShotLimit: integer('monthly_shot_limit').notNull().default(40),
   rules: text('rules').notNull()
 });
 


### PR DESCRIPTION
### Motivation
- Introduce a configurable per-season monthly shot cap so admins can change the default (40) and correct mistakes. 
- Surface the remaining monthly shots in the shot-recording modal and allow admins to override with a confirmation when the cap is reached.

### Description
- Added a new admin UI `AdjustMonthlyShotLimit` component and stylesheet at `src/components/AdjustMonthlyShotLimit.tsx` / `.module.css` to view and update the active season `monthly_shot_limit`.
- Wired the new control into the current season controls by adding the tab and rendering `AdjustMonthlyShotLimit` from `src/components/CurrentSeason/CurrentSeasonModal.tsx`.
- Displayed a `Monthly Shots Left: XX` indicator in the player shot modal by updating `src/components/Modal/Modal.tsx` and `src/components/Modal/modal.css`, including logic to fetch shots for the current month and recalculate remaining monthly shots in real time.
- When a player has no monthly shots left, submitting a shot now triggers an override confirmation dialog in `Modal.tsx` and proceeds only if confirmed.
- Added schema and persistence for the monthly limit: updated `src/db/schema.ts` to include `monthly_shot_limit` (default 40) on `seasons`, and ensured new seasons created by `src/components/NextSeason/NextSeason.tsx` set `monthly_shot_limit: 40` by default.

### Testing
- Started the dev server with `npm run dev`; Next.js compiled and the app served locally (Next started), but the environment failed to fetch Google Fonts causing a font fetch warning and fallback (this is a network restriction in the test environment). (succeeded with font fallback)
- Captured a page screenshot with an automated Playwright script to verify the modal header layout and that the monthly shots UI renders; screenshot generation succeeded and artifact was produced (`artifacts/monthly-shots-modal.png`). (succeeded)
- No DB migration was executed here; the schema change (`monthly_shot_limit`) requires applying a migration in production (not run by these automated dev tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985cd55300c832c86144d08c4e7c005)