### PR TITLE
Add waiver “W” badge to player buttons in Admin standings

### DIFF
--- a/src/app/Admin/adminPage.module.css
+++ b/src/app/Admin/adminPage.module.css
@@ -190,6 +190,28 @@
   display: flex;
   justify-content: center;
   white-space: nowrap;
+  position: relative;
+}
+
+.playerName {
+  padding-right: 18px;
+}
+
+.waiverBadge {
+  position: absolute;
+  top: 6px;
+  right: 8px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background-color: #e76f51;
+  color: #fff;
+  font-size: 0.65rem;
+  font-weight: 700;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  text-transform: uppercase;
 }
 
 

--- a/src/app/Admin/page.tsx
+++ b/src/app/Admin/page.tsx
@@ -1,5 +1,5 @@
 'use client'; 
-import React, { useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import styles from './adminPage.module.css'; // Import the combined CSS module
 import Modal from '@/components/Modal/Modal';
@@ -63,6 +63,7 @@ const AdminPage = () => {
   const [isAdmin, setIsAdmin] = useState<boolean>(false); // Admin check
   const [seasonName, setSeasonName] = useState<string>(''); // Active season name
   const [userView, setUserView] = useState<string>(''); // User's current view setting
+  const [waiverByPlayerId, setWaiverByPlayerId] = useState<Record<number, boolean>>({});
 
   const pageOptions = ['Standings', 'FreeAgent', 'Rules', 'Shot History'];
 
@@ -177,6 +178,95 @@ const AdminPage = () => {
 
     fetchSeasonName();
   }, []);
+
+  const fetchWaiverStatus = useCallback(async () => {
+    try {
+      const { data: activeSeason, error: seasonError } = await supabase
+        .from('seasons')
+        .select('season_id')
+        .is('end_date', null)
+        .maybeSingle();
+
+      if (seasonError) {
+        throw seasonError;
+      }
+
+      if (!activeSeason) {
+        setWaiverByPlayerId({});
+        return;
+      }
+
+      const { data: instances, error: instanceError } = await supabase
+        .from('player_instance')
+        .select('player_instance_id, player_id')
+        .eq('season_id', activeSeason.season_id);
+
+      if (instanceError) {
+        throw instanceError;
+      }
+
+      if (!instances || instances.length === 0) {
+        setWaiverByPlayerId({});
+        return;
+      }
+
+      const instanceIds = instances.map((instance) => instance.player_instance_id);
+      const instanceToPlayer = new Map(
+        instances.map((instance) => [instance.player_instance_id, instance.player_id]),
+      );
+
+      const startOfDay = new Date();
+      startOfDay.setHours(0, 0, 0, 0);
+      const startOfNextDay = new Date(startOfDay);
+      startOfNextDay.setDate(startOfNextDay.getDate() + 1);
+
+      const { data: shots, error: shotsError } = await supabase
+        .from('shots')
+        .select('instance_id')
+        .in('instance_id', instanceIds)
+        .gte('shot_date', startOfDay.toISOString())
+        .lt('shot_date', startOfNextDay.toISOString());
+
+      if (shotsError) {
+        throw shotsError;
+      }
+
+      const shotsByPlayer = new Map<number, number>();
+      (shots || []).forEach((shot) => {
+        const playerId = instanceToPlayer.get(shot.instance_id);
+        if (!playerId) return;
+        shotsByPlayer.set(playerId, (shotsByPlayer.get(playerId) || 0) + 1);
+      });
+
+      const nextWaiverByPlayer: Record<number, boolean> = {};
+      shotsByPlayer.forEach((count, playerId) => {
+        nextWaiverByPlayer[playerId] = count >= 4;
+      });
+
+      setWaiverByPlayerId(nextWaiverByPlayer);
+    } catch (error) {
+      console.error('Error fetching waiver status:', error);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchWaiverStatus();
+
+    const shotsChannel = supabase
+      .channel('waiver-status-shot-changes')
+      .on('postgres_changes', { event: '*', schema: 'public', table: 'shots' }, fetchWaiverStatus)
+      .subscribe();
+
+    const instanceChannel = supabase
+      .channel('waiver-status-instance-changes')
+      .on('postgres_changes', { event: '*', schema: 'public', table: 'player_instance' }, fetchWaiverStatus)
+      .subscribe();
+
+    return () => {
+      supabase.removeChannel(shotsChannel);
+      supabase.removeChannel(instanceChannel);
+    };
+  }, [fetchWaiverStatus]);
 
   // Modal handlers
   const handleOpenModal = (playerId: number, name: string) => {
@@ -318,7 +408,12 @@ const AdminPage = () => {
                           onClick={() => handleOpenModal(player.player_id, player.name)}
                           style={{ color: tier.color }}
                         >
-                          {player.name}
+                          <span className={styles.playerName}>{player.name}</span>
+                          {waiverByPlayerId[player.player_id] && (
+                            <span className={styles.waiverBadge} aria-label="Waiver shot" title="Waiver shot">
+                              W
+                            </span>
+                          )}
                         </div>
                       ))}
                   </div>


### PR DESCRIPTION
### Motivation
- Make waiver shots visible at-a-glance in the Admin standings so a player who has already taken 4 shots today shows a waiver indicator on their record button.

### Description
- Compute per-player daily waiver status by querying the active season, mapping `player_instance` → `player_id`, counting today’s `shots`, and marking players with count >= 4 in `waiverByPlayerId` state using `fetchWaiverStatus` and `useCallback`.
- Subscribe to realtime updates for `shots` and `player_instance` so badge state refreshes automatically when data changes.
- Render a small circular `W` badge inside each player box when the player has a waiver shot and add spacing for the player name.
- Files changed: `src/app/Admin/page.tsx` (logic + rendering) and `src/app/Admin/adminPage.module.css` (styles); also added `useCallback` import.

### Testing
- Started the dev server with `npm run dev -- --hostname 0.0.0.0 --port 3000`, which compiled and served the app (Next.js reported a Google Fonts fetch warning but fell back to local fonts). 
- Captured a screenshot of the `/Admin` page with a Playwright script to verify the badge rendered; the page returned `GET /Admin 200` and produced the screenshot artifact. 
- No automated unit tests were modified or added; the manual render+capture check succeeded despite the font fetch warning.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985ce1365e4832c8ab2faf1ffe78280)