### PR TITLE
Remove temporary 'Test' player from Direwolves (data migration)

### DIFF
--- a/supabase/migrations/20250214120000_remove_test_player.sql
+++ b/supabase/migrations/20250214120000_remove_test_player.sql
@@ -1,0 +1,8 @@
+DELETE FROM players
+WHERE name = 'Test'
+  AND team_id = (
+    SELECT team_id
+    FROM teams
+    WHERE team_name = 'Direwolves'
+    LIMIT 1
+  );


### PR DESCRIPTION
### Motivation
- Remove a temporary `Test` player that was added to the Direwolves roster and is skewing team totals (shots left and points per shot). 

### Description
- Add a data-only migration `supabase/migrations/20250214120000_remove_test_player.sql` which deletes the `players` row where `name = 'Test'` and `team_id` matches the `Direwolves` team. 

### Testing
- No automated tests were run for this data-only migration.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985d109c6a8832c8b48dd7a18fc66bd)