### PR TITLE
Add frontend FFA standings mode for individual leaderboard display

### DIFF
--- a/src/app/Standings/StandingsPage.module.css
+++ b/src/app/Standings/StandingsPage.module.css
@@ -77,6 +77,33 @@
   border-bottom: 1px solid #ddd;
 }
 
+.ffaHeaderRow,
+.ffaRow {
+  grid-template-columns: 0.7fr 2fr 1fr 1fr 1fr;
+}
+
+.ffaRow:nth-child(even) {
+  background-color: #f7f9fb;
+}
+
+.ffaLeaderRow {
+  background-color: #edf6f9;
+}
+
+.ffaRankBadge {
+  justify-self: center;
+  width: 30px;
+  height: 30px;
+  border-radius: 999px;
+  background-color: #264653;
+  color: #fff;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 1rem;
+  font-weight: 700;
+}
+
 .playerName{
   display: inline-flex; /* Ensures the circle and name stay on the same line */
   align-items: center;  /* Vertically aligns the circle and name */

--- a/src/app/Standings/page.tsx
+++ b/src/app/Standings/page.tsx
@@ -21,6 +21,7 @@ interface Team {
 }
 
 interface TeamWithPlayers {
+  team_id?: number;
   team_name: string;
   players: {
     shots_taken: number;
@@ -288,6 +289,9 @@ const StandingsPage: React.FC = () => {
   rules: ''
  }); // Current season info
  const router = useRouter(); // Router for navigation
+ const isFfaSeason = season.season_name.toLowerCase().includes('ffa')
+  || season.season_name.toLowerCase().includes('free for all');
+ const isFfaTeam = (teamName: string) => teamName === 'Free For All';
 
   /**
    * Signs out the current user and redirects to the home page.
@@ -404,6 +408,7 @@ const StandingsPage: React.FC = () => {
           const teamPointsPerShot = totalShotsTaken > 0 ? team.team_score / totalShotsTaken : 0;
 
           return {
+            team_id: team.team_id,
             team_name: team.team_name,
             players: playersWithStats,
             team_pps: teamPointsPerShot,
@@ -606,19 +611,71 @@ const StandingsPage: React.FC = () => {
                     <span className={styles.statValue}>{team.total_shots}</span>
                   </div>
                   <div className={styles.statBox}>
-                    <span className={styles.statLabel}>PPS</span>
+                    <span className={styles.statLabel}>{(isFfaSeason || isFfaTeam(team.team_name)) ? 'Avg PPS' : 'PPS'}</span>
                     <span className={styles.statValue}>{team.team_pps.toFixed(2)}</span>
                   </div>
                 </div>
                 {/* Table Headers */}
-                <div className={styles.row}>
-                  <span className={styles.columnHeader}>Name</span>
-                  <span className={styles.columnHeader}>Score</span>
-                  <span className={styles.columnHeader}>SL</span>
-                  <span className={styles.columnHeader}>PPS</span>
-                </div>
-                {team.players.map((player, playerIndex) => (
-                  <div key={playerIndex} className={styles.row}>
+                {(isFfaSeason || isFfaTeam(team.team_name)) ? (
+                  <>
+                    <div className={`${styles.row} ${styles.ffaHeaderRow}`}>
+                      <span className={styles.columnHeader}>#</span>
+                      <span className={styles.columnHeader}>Player</span>
+                      <span className={styles.columnHeader}>Score</span>
+                      <span className={styles.columnHeader}>SL</span>
+                      <span className={styles.columnHeader}>PPS</span>
+                    </div>
+                    {[...team.players]
+                      .sort((a, b) => {
+                        if (b.player_score !== a.player_score) return b.player_score - a.player_score;
+                        if (b.pps !== a.pps) return b.pps - a.pps;
+                        if (a.shots_left !== b.shots_left) return a.shots_left - b.shots_left;
+                        return a.name.localeCompare(b.name);
+                      })
+                      .map((player, playerIndex) => (
+                      <div
+                        key={playerIndex}
+                        className={`${styles.row} ${styles.ffaRow} ${playerIndex === 0 ? styles.ffaLeaderRow : ''}`}
+                      >
+                        <span className={styles.ffaRankBadge}>{playerIndex + 1}</span>
+                        <div className={styles.playerNameColumn}>
+                          <div
+                            className={styles.playerName}
+                            style={{
+                              backgroundImage: `linear-gradient(90deg, ${player.tier_color}33 0%, ${player.tier_color}1A 60%, transparent 100%)`,
+                            }}
+                          >
+                            <span className={styles.playerNameText}>{player.name}</span>
+                          </div>
+                        </div>
+                        <span className={styles.totalPoints}>{player.player_score}</span>
+                        <div className={styles.shotsLeft}>
+                          <span className={styles.shotsLeftValue}>{player.shots_left}</span>
+                          {player.shots_left_dashes > 0 && (
+                            <span
+                              className={styles.shotsLeftDashes}
+                              aria-label={`${player.shots_left_dashes} shots left dashes`}
+                            >
+                              {Array.from({ length: player.shots_left_dashes }).map((_, index) => (
+                                <span key={index} className={styles.shotsLeftDash} />
+                              ))}
+                            </span>
+                          )}
+                        </div>
+                        <span className={styles.pps}>{player.pps.toFixed(2)}</span>
+                      </div>
+                    ))}
+                  </>
+                ) : (
+                  <>
+                    <div className={styles.row}>
+                      <span className={styles.columnHeader}>Name</span>
+                      <span className={styles.columnHeader}>Score</span>
+                      <span className={styles.columnHeader}>SL</span>
+                      <span className={styles.columnHeader}>PPS</span>
+                    </div>
+                    {team.players.map((player, playerIndex) => (
+                      <div key={playerIndex} className={styles.row}>
                     {/* Player Name and Icons */}
                     <div className={styles.playerNameColumn}>
                       <div
@@ -668,7 +725,9 @@ const StandingsPage: React.FC = () => {
                   </div>
                   <span className={styles.pps}>{player.pps.toFixed(2)}</span>
                 </div>
-              ))}
+                    ))}
+                  </>
+                )}
               </div>
             ))}
           </div>


### PR DESCRIPTION
### Motivation
- Free For All seasons currently render everyone as one fake team which looks incorrect, so a frontend-only fix was needed to present FFA competitors as individual leaderboard rows without changing backend/schema.
- Detect FFA safely in the client using the season name (`FFA` / `Free For All`) or exact team name (`Free For All`) so regular team seasons stay unchanged.

### Description
- Added FFA detection helpers and a conditional rendering path in `src/app/Standings/page.tsx` that renders an individual-competitor leaderboard when the season name includes `FFA`/`Free for All` or the team name equals `Free For All`.
- Implemented FFA UI rows that show rank, player name, score, shots left (with dashes), PPS, subtle leader highlighting, alternating row backgrounds, and optional tier color chips while preserving the existing styling language and stat cards; minor `TeamWithPlayers` typing and `team_id` exposure added to keep logic local to the page.
- Implemented stable FFA sorting in the UI: score (desc), PPS (desc), shots left (asc), then name (asc) as a final tiebreaker; non-FFA seasons continue to use the original grouped team layout unchanged.
- Added small CSS additions in `src/app/Standings/StandingsPage.module.css` for `.ffaRow`, `.ffaHeaderRow`, `.ffaLeaderRow`, and `.ffaRankBadge` to provide rank badges and subtle visual polish while keeping existing layout rules intact.

### Testing
- Ran `npm run lint`; lint completed successfully and reported an existing unrelated warning in `src/app/Admin/page.tsx` about a missing `useEffect` dependency which was not introduced by this change.
- Ran `npm run build`; the build completed successfully with non-blocking Next.js recommendations about the optional `sharp` package and Browserslist freshness, and the new FFA rendering compiles cleanly.
- No backend, schema, or API changes were made or required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f53b8e4188832ebd5f01ad015328af)