### PR TITLE
Make admin shot-entry player picker touch-friendly with responsive grid

### DIFF
--- a/src/app/Admin/adminPage.module.css
+++ b/src/app/Admin/adminPage.module.css
@@ -79,7 +79,7 @@
 /* Footer styling */
 .adminFooter {
   width: 100%;
-  padding: 10px;
+  padding: 14px 12px;
   text-align: center;
   background-color: #2a9d8f;
   color: white;
@@ -178,6 +178,19 @@
 }
 
 
+
+.playerList {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.playerGrid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 12px;
+}
+
 .header {
   grid-column: 1 / -1;
   font-weight: bold;
@@ -195,6 +208,8 @@
   transition: background-color 0.3s ease;
   display: flex;
   justify-content: center;
+  align-items: center;
+  min-height: 56px;
   white-space: nowrap;
   position: relative;
 }

--- a/src/app/Admin/page.tsx
+++ b/src/app/Admin/page.tsx
@@ -475,28 +475,33 @@ const AdminPage = () => {
             <div className={styles.players}>
               {tiers
                 .filter((tier) => tier.players.some((player) => !player.is_hidden))
-                .map((tier) => (
-                  <div key={tier.tier_name} className={styles.column}>
-                    <div className={styles.header}>{tier.tier_name}</div>
-                    {tier.players
-                      .filter((player) => !player.is_hidden)
-                      .map((player) => (
-                        <div
-                          key={player.player_id}
-                          className={styles.box}
-                          onClick={() => handleOpenModal(player.player_id, player.name)}
-                          style={{ color: tier.color }}
-                        >
-                          <span className={styles.playerName}>{player.name}</span>
-                          {waiverByPlayerId[player.player_id] && (
-                            <span className={styles.waiverBadge} aria-label="Waiver shot" title="Waiver shot">
-                              W
-                            </span>
-                          )}
-                        </div>
-                      ))}
-                  </div>
-                ))}
+                .map((tier) => {
+                  const visiblePlayers = tier.players.filter((player) => !player.is_hidden);
+                  const usePlayerGrid = visiblePlayers.length > 6;
+
+                  return (
+                    <div key={tier.tier_name} className={styles.column}>
+                      <div className={styles.header}>{tier.tier_name}</div>
+                      <div className={usePlayerGrid ? styles.playerGrid : styles.playerList}>
+                        {visiblePlayers.map((player) => (
+                          <div
+                            key={player.player_id}
+                            className={styles.box}
+                            onClick={() => handleOpenModal(player.player_id, player.name)}
+                            style={{ color: tier.color }}
+                          >
+                            <span className={styles.playerName}>{player.name}</span>
+                            {waiverByPlayerId[player.player_id] && (
+                              <span className={styles.waiverBadge} aria-label="Waiver shot" title="Waiver shot">
+                                W
+                              </span>
+                            )}
+                          </div>
+                        ))}
+                      </div>
+                    </div>
+                  );
+                })}
             </div>
           )}
         </div>


### PR DESCRIPTION
### Motivation
- The admin shot-entry view stacks many player buttons vertically when everyone is in the same tier, which is awkward on tablets and makes touch targets inefficient.
- The change aims to improve touch ergonomics without touching any backend, data, or shot-recording logic.

### Description
- Render each tier’s players as a responsive grid when that tier has more than 6 visible players, otherwise keep the existing vertical list; implemented in `src/app/Admin/page.tsx` by computing `visiblePlayers` and `usePlayerGrid` (threshold: >6).
- Added `.playerGrid` and `.playerList` layout helpers and adjusted player tile styles in `src/app/Admin/adminPage.module.css` using `repeat(auto-fit, minmax(140px, 1fr))`, `gap: 12px`, and a touch-friendly `min-height: 56px` so buttons are larger and spaced comfortably.
- Preserved all existing click handlers and shot-recording flow (no backend, schema, API, or business-logic changes); tier headers and normal grouping behavior remain intact.
- Kept Buckets visual style by reusing existing `.box`, `.header`, and badge styles while only adjusting spacing and alignment.

### Testing
- Ran `npm run lint` which completed successfully but reports a pre-existing `react-hooks/exhaustive-deps` warning in `src/app/Admin/page.tsx` (unchanged by this PR).
- Ran `npm run build` which completed successfully (includes the same lint warning and the standard Next.js optional `sharp` advisory).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f5425644e4832eb3787846dae9c8d8)