### PR TITLE
Hide team aggregate summary cards for Free For All standings

### DIFF
--- a/src/app/Standings/page.tsx
+++ b/src/app/Standings/page.tsx
@@ -583,7 +583,10 @@ const StandingsPage: React.FC = () => {
         {/* Standings View*/}
         <div className={styles.container}>
           <div className={styles.teams}>
-            {teams.map((team, index) => (
+            {teams.map((team, index) => {
+              const isFreeForAll = isFfaSeason || isFfaTeam(team.team_name);
+
+              return (
               <div
                 key={index}
                 className={`${styles.team} ${teamBorderClassMap[team.team_name] ?? ''}`}
@@ -601,22 +604,24 @@ const StandingsPage: React.FC = () => {
                     />
                   )}
                 </div>
-                <div className={styles.teamStatsGrid}>
-                  <div className={styles.statBox}>
-                    <span className={styles.statLabel}>Total Score</span>
-                    <span className={styles.statValue}>{team.team_score}</span>
+                {!isFreeForAll && (
+                  <div className={styles.teamStatsGrid}>
+                    <div className={styles.statBox}>
+                      <span className={styles.statLabel}>Total Score</span>
+                      <span className={styles.statValue}>{team.team_score}</span>
+                    </div>
+                    <div className={styles.statBox}>
+                      <span className={styles.statLabel}>Shots Left</span>
+                      <span className={styles.statValue}>{team.total_shots}</span>
+                    </div>
+                    <div className={styles.statBox}>
+                      <span className={styles.statLabel}>PPS</span>
+                      <span className={styles.statValue}>{team.team_pps.toFixed(2)}</span>
+                    </div>
                   </div>
-                  <div className={styles.statBox}>
-                    <span className={styles.statLabel}>Shots Left</span>
-                    <span className={styles.statValue}>{team.total_shots}</span>
-                  </div>
-                  <div className={styles.statBox}>
-                    <span className={styles.statLabel}>{(isFfaSeason || isFfaTeam(team.team_name)) ? 'Avg PPS' : 'PPS'}</span>
-                    <span className={styles.statValue}>{team.team_pps.toFixed(2)}</span>
-                  </div>
-                </div>
+                )}
                 {/* Table Headers */}
-                {(isFfaSeason || isFfaTeam(team.team_name)) ? (
+                {isFreeForAll ? (
                   <>
                     <div className={`${styles.row} ${styles.ffaHeaderRow}`}>
                       <span className={styles.columnHeader}>#</span>
@@ -729,7 +734,8 @@ const StandingsPage: React.FC = () => {
                   </>
                 )}
               </div>
-            ))}
+            );
+            })}
           </div>
         </div>
     </main>


### PR DESCRIPTION
### Motivation
- The Free For All mode uses a fake team but should present individual player standings without misleading team aggregate totals.
- The UI must hide team-style summary stats (Total Score, Shots Left, PPS) when the season/team is FFA while preserving normal team behavior.

### Description
- Updated `src/app/Standings/page.tsx` to compute a single `isFreeForAll` flag per team row using the existing detection (`isFfaSeason || isFfaTeam(team.team_name)`).
- Wrapped the team summary stats grid (Total Score, Shots Left, PPS) in a conditional so it only renders when `!isFreeForAll` and is omitted for FFA rows.
- Left FFA rendering for player-level rows unchanged so individual rows still show Rank, Name, Score, Shots Left, and PPS.
- No backend, API, schema, or score/shot calculation logic was modified; change is localized to the standings page.

### Testing
- Ran `npm run lint` which completed successfully; an existing unrelated ESLint warning remains in `src/app/Admin/page.tsx` about a missing hook dependency.
- Ran `npm run build` which completed successfully; build emitted non-blocking warnings about optional `sharp` and an outdated `caniuse-lite` database.
- Confirmed the only edited file is `src/app/Standings/page.tsx` and the app compiles with the UI conditional in place.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f545d0be4c832ea648355ae91a3f9c)