### PR TITLE
Hide fake Free For All team rank badge in standings

### DIFF
--- a/src/app/Standings/page.tsx
+++ b/src/app/Standings/page.tsx
@@ -610,15 +610,19 @@ const StandingsPage: React.FC = () => {
           <div className={styles.teams}>
             {teams.map((team, index) => {
               const isFreeForAll = isFfaSeason || isFfaTeam(team.team_name);
+              const isFakeFfaTeam = isFfaTeam(team.team_name);
+              const showTeamRankBadge = !isFakeFfaTeam;
 
               return (
               <div
                 key={index}
-                className={`${styles.team} ${teamBorderClassMap[team.team_name] ?? ''} ${index === 0 ? styles.teamLeader : ''}`}
+                className={`${styles.team} ${teamBorderClassMap[team.team_name] ?? ''} ${index === 0 && !isFakeFfaTeam ? styles.teamLeader : ''}`}
               >
                 {/* Team Title */}
                 <div className={styles.teamHeader}>
-                  <span className={`${styles.teamRankBadge} ${rankClassByIndex(index)}`}>#{index + 1}</span>
+                  {showTeamRankBadge && (
+                    <span className={`${styles.teamRankBadge} ${rankClassByIndex(index)}`}>#{index + 1}</span>
+                  )}
                   {teamLogoMap[team.team_name] && (
                     <div className={styles.teamLogoWrap}>
                     <Image


### PR DESCRIPTION
### Motivation
- The Fake "Free For All" team currently displays a team placement/rank (e.g. "#1"), which is misleading because it is a backend placeholder used for individual FFA leaderboards.

### Description
- Added `isFakeFfaTeam = isFfaTeam(team.team_name)` and `showTeamRankBadge = !isFakeFfaTeam` in `src/app/Standings/page.tsx` and conditionally render the team rank badge so the rank is hidden when `team_name === "Free For All"`.
- Prevent the fake FFA team from receiving the `teamLeader` visual treatment by skipping `styles.teamLeader` when the team is the fake FFA placeholder, while leaving all other UI and scoring logic unchanged.

### Testing
- Ran `npm run lint` which completed (existing unrelated warning in `src/app/Admin/page.tsx` remains). 
- Ran `npm run build` which produced a successful production build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f54a12cc98832eae1e4c563975b0b8)