### PR TITLE
Add TV-friendly live Shot History panel to Standings

### DIFF
--- a/src/app/Standings/StandingsPage.module.css
+++ b/src/app/Standings/StandingsPage.module.css
@@ -23,6 +23,15 @@
   gap: 18px;
 }
 
+.contentGrid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.8fr) minmax(300px, 1fr);
+  gap: 16px;
+  align-items: start;
+}
+
+.standingsPanel { min-width: 0; }
+
 .pageSummary {
   display: flex;
   justify-content: space-between;
@@ -45,6 +54,32 @@
   gap: 16px;
   width: 100%;
 }
+
+.shotHistoryPanel {
+  background: #ffffff;
+  border: 2px solid #d8dee9;
+  border-radius: 16px;
+  box-shadow: 0 0 0 3px #f0f4f8, 0 10px 24px rgba(15, 23, 42, 0.08);
+  padding: 14px;
+  max-height: 78vh;
+  display: flex;
+  flex-direction: column;
+}
+.shotHistoryHeader { display: flex; justify-content: space-between; align-items: center; gap: 10px; margin-bottom: 4px; }
+.shotHistoryTitle { margin: 0; font-size: 1.2rem; font-weight: 800; color:#0f172a; }
+.livePill { background:#dcfce7; color:#166534; border-radius:999px; padding:4px 10px; font-size:.75rem; font-weight:800; letter-spacing:.05em; text-transform:uppercase; }
+.shotHistorySubtle { margin: 0 0 10px; color:#64748b; font-size:.92rem; }
+.shotHistoryState { border:1px dashed #cbd5e1; border-radius:12px; padding:14px; color:#475569; display:flex; flex-direction:column; gap:4px; }
+.shotHistoryList { list-style:none; margin:0; padding:0; overflow:auto; display:flex; flex-direction:column; gap:10px; }
+.shotHistoryItem { border:1px solid #e2e8f0; border-radius:12px; padding:10px; background:#f8fafc; }
+.shotTopRow { display:flex; justify-content:space-between; align-items:flex-start; gap:10px; }
+.shotPlayerWrap { display:flex; align-items:center; gap:8px; min-width:0; }
+.shotPlayer { font-size:1rem; font-weight:700; color:#0f172a; white-space:nowrap; overflow:hidden; text-overflow:ellipsis; }
+.tierChip { display:inline-flex; align-items:center; border-radius:999px; padding:3px 8px; color:#fff; font-size:.72rem; font-weight:700; }
+.shotResult { font-weight:800; font-size:1rem; }
+.shotMade { color:#166534; }
+.shotMiss { color:#7f1d1d; }
+.shotMeta { margin-top:6px; color:#64748b; font-size:.84rem; }
 
 .team {
   display: flex;
@@ -108,8 +143,10 @@
 .signOutButton { background:#c1121f; color:#fff; border:none; border-radius:8px; padding:8px 14px; font-weight:700; }
 
 @media (max-width: 900px) {
+  .contentGrid { grid-template-columns: 1fr; }
   .teams { grid-template-columns: 1fr; }
   .pageSummary { flex-direction: column; align-items:flex-start; }
+  .shotHistoryPanel { max-height: none; }
 }
 @media (max-width: 640px) {
   .userContent { padding: 10px; }

--- a/src/app/Standings/page.tsx
+++ b/src/app/Standings/page.tsx
@@ -47,6 +47,15 @@ interface Season {
   rules: string;
 }
 
+interface ShotFeedItem {
+  shot_id: number;
+  shot_date: string;
+  result: number;
+  player_name: string;
+  tier_name: string | null;
+  tier_color: string | null;
+}
+
 const teamLogoMap: Record<string, StaticImageData> = {
   Direwolves: direwolvesLogo,
   Monstars: monstarsLogo,
@@ -289,6 +298,9 @@ const StandingsPage: React.FC = () => {
   shot_total: -1,
   rules: ''
  }); // Current season info
+ const [recentShots, setRecentShots] = useState<ShotFeedItem[]>([]);
+ const [isShotHistoryLoading, setIsShotHistoryLoading] = useState<boolean>(true);
+ const [shotHistoryError, setShotHistoryError] = useState<string | null>(null);
  const router = useRouter(); // Router for navigation
  const isFfaSeason = season.season_name.toLowerCase().includes('ffa')
   || season.season_name.toLowerCase().includes('free for all');
@@ -301,6 +313,59 @@ const StandingsPage: React.FC = () => {
  };
 
  const totalPlayers = useMemo(() => teams.reduce((acc, team) => acc + team.players.length, 0), [teams]);
+ const formatShotTime = (shotDate: string) => {
+  const parsed = new Date(shotDate);
+  if (Number.isNaN(parsed.getTime())) return 'Unknown time';
+  return parsed.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
+ };
+
+ const formatShotResult = (result: number) => {
+  if (result > 0) return `+${result}`;
+  if (result === 0) return 'Miss';
+  return `${result}`;
+ };
+
+ const fetchShotHistory = async (seasonId: number) => {
+  try {
+    setIsShotHistoryLoading(true);
+    setShotHistoryError(null);
+    const { data, error } = await supabase
+      .from('shots')
+      .select(`
+        shot_id,
+        shot_date,
+        result,
+        tier_id,
+        player_instance!inner(
+          season_id,
+          players!inner(name)
+        ),
+        tiers(tier_name, color)
+      `)
+      .eq('player_instance.season_id', seasonId)
+      .order('shot_date', { ascending: false })
+      .limit(15);
+
+    if (error) throw error;
+
+    const mapped: ShotFeedItem[] = (data ?? []).map((shot: any) => ({
+      shot_id: shot.shot_id,
+      shot_date: shot.shot_date,
+      result: Number(shot.result) || 0,
+      player_name: shot.player_instance?.players?.name ?? 'Unknown player',
+      tier_name: shot.tiers?.tier_name ?? null,
+      tier_color: shot.tiers?.color ?? null,
+    }));
+
+    setRecentShots(mapped);
+  } catch (error) {
+    console.error('Error fetching shot history:', error);
+    setShotHistoryError('Unable to load live shot feed.');
+    setRecentShots([]);
+  } finally {
+    setIsShotHistoryLoading(false);
+  }
+ };
 
   /**
    * Signs out the current user and redirects to the home page.
@@ -338,6 +403,7 @@ const StandingsPage: React.FC = () => {
 
       const activeSeasonId = activeSeason.season_id;
       setSeason(activeSeason);
+      await fetchShotHistory(activeSeasonId);
         // Fetch teams
 
       const { data: teamsData, error: teamsError } = await supabase
@@ -571,6 +637,9 @@ const StandingsPage: React.FC = () => {
               }
               await fetchTeamsAndPlayers();
               await updateTeamScores();
+              if (season.season_id !== -1) {
+                await fetchShotHistory(season.season_id);
+              }
             } catch (error) {
               console.error('Error processing shot change:', error);
             }
@@ -584,7 +653,7 @@ const StandingsPage: React.FC = () => {
         supabase.removeChannel(playerChannel);
         supabase.removeChannel(shotChannel);
       };
-  }, [userView ]);
+  }, [userView, season.season_id ]);
 
  return (
   <div className={styles.userContainer}>
@@ -607,8 +676,10 @@ const StandingsPage: React.FC = () => {
           </section>
           {isLoading && <section className={styles.pageSummary}><div className={styles.summaryTitle}>Loading standings…</div></section>}
           {!isLoading && teams.length === 0 && <section className={styles.pageSummary}><div className={styles.summaryTitle}>No visible teams or players yet.</div></section>}
-          <div className={styles.teams}>
-            {teams.map((team, index) => {
+          <div className={styles.contentGrid}>
+            <section className={styles.standingsPanel} aria-label="Standings list">
+              <div className={styles.teams}>
+                {teams.map((team, index) => {
               const isFreeForAll = isFfaSeason || isFfaTeam(team.team_name);
               const isFakeFfaTeam = isFfaTeam(team.team_name);
               const showTeamRankBadge = !isFakeFfaTeam;
@@ -765,9 +836,54 @@ const StandingsPage: React.FC = () => {
                     ))}
                   </>
                 )}
+                </div>
+              );
+              })}
               </div>
-            );
-            })}
+            </section>
+            <aside className={styles.shotHistoryPanel} aria-label="Live shot history">
+              <div className={styles.shotHistoryHeader}>
+                <h2 className={styles.shotHistoryTitle}>Shot History</h2>
+                <span className={styles.livePill}>Live</span>
+              </div>
+              <p className={styles.shotHistorySubtle}>Recent makes and misses for this season.</p>
+              {isShotHistoryLoading && (
+                <div className={styles.shotHistoryState}>Loading live feed…</div>
+              )}
+              {!isShotHistoryLoading && shotHistoryError && (
+                <div className={styles.shotHistoryState}>{shotHistoryError}</div>
+              )}
+              {!isShotHistoryLoading && !shotHistoryError && recentShots.length === 0 && (
+                <div className={styles.shotHistoryState}>
+                  <strong>No shots recorded yet.</strong>
+                  <span>Shot activity will appear here live.</span>
+                </div>
+              )}
+              {!isShotHistoryLoading && !shotHistoryError && recentShots.length > 0 && (
+                <ul className={styles.shotHistoryList}>
+                  {recentShots.map((shot, index) => (
+                    <li key={`${shot.shot_id}-${index}`} className={styles.shotHistoryItem}>
+                      <div className={styles.shotTopRow}>
+                        <div className={styles.shotPlayerWrap}>
+                          <span className={styles.shotPlayer}>{shot.player_name}</span>
+                          {shot.tier_color && (
+                            <span className={styles.tierChip} style={{ backgroundColor: shot.tier_color }}>
+                              {shot.tier_name || 'Tier'}
+                            </span>
+                          )}
+                        </div>
+                        <span className={`${styles.shotResult} ${shot.result > 0 ? styles.shotMade : styles.shotMiss}`}>
+                          {shot.result > 1 ? '🔥 ' : ''}{formatShotResult(shot.result)}
+                        </span>
+                      </div>
+                      <div className={styles.shotMeta}>
+                        {formatShotTime(shot.shot_date)}
+                      </div>
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </aside>
           </div>
         </div>
     </main>


### PR DESCRIPTION
### Motivation
- Provide a TV-friendly live activity feed beside the refreshed Standings so viewers can see recent shots in real time without changing backend schema or scoring behavior.
- Reuse existing Supabase realtime subscriptions and current season/standings data patterns to avoid heavy polling and keep frontend-focused changes.
- Keep Free For All (FFA) behavior intact by showing individual player names (not the fake FFA team) in the feed.

### Description
- Added a new `ShotFeedItem` type and local state (`recentShots`, `isShotHistoryLoading`, `shotHistoryError`) and a `fetchShotHistory` helper to query recent shots for the active season; query joins `player_instance -> players` and optional `tiers`, orders by `shot_date desc`, and limits to 15 rows. (modified `src/app/Standings/page.tsx`)
- Integrated realtime refresh by calling `fetchShotHistory(season.season_id)` from the existing `shots` Supabase channel handler so the feed updates on inserts/updates/deletes and cleans up channels on unmount. (modified `src/app/Standings/page.tsx`)
- Added a standalone Shot History UI card and responsive layout: standings and shot history render side-by-side on wide/TV screens and stack on small screens; included loading, empty, and error states, a `Live` pill, readable timestamps, result formatting, optional tier chip, and subtle visual indicators for made/missed/high-value shots. (modified `src/app/Standings/page.tsx` and `src/app/Standings/StandingsPage.module.css`)
- Preserved all existing logic: no schema, scoring, or shot recording changes; FFA behavior retained by deriving actor text from joined `players.name` when available.

### Testing
- Ran `npm run lint` which completed successfully with the repo's existing hook dependency warnings (non-blocking) in `src/app/Admin/page.tsx` and `src/app/Standings/page.tsx`.
- Ran `npm run build` which completed a successful production build with the same non-blocking warnings and the standard Next.js notices.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8863761d4832e93101562ffa0757c)