### PR TITLE
Fix fire/cold streak indicators in Free For All standings

### DIFF
--- a/src/app/Standings/page.tsx
+++ b/src/app/Standings/page.tsx
@@ -133,6 +133,31 @@ const FlameIcon = () => (
   </span>
 );
 
+const PlayerStatusIcons: React.FC<{ player: TeamWithPlayers['players'][number] }> = ({ player }) => (
+  <>
+    {player.name === 'A. Begy' && (
+      <span className={styles.crownIcon}>👑</span>
+    )}
+    {player.shots_left % 10 === 1 && (
+      <span className={styles.moneyballIcon} aria-label="Moneyball shot">
+        <FaDollarSign />
+      </span>
+    )}
+    {/* Fire Icon: 3+ Consecutive Makes */}
+    {player.shots_made_in_row >= 3 && (
+      <span className={styles.fireIcon}>
+        <FlameIcon />
+      </span>
+    )}
+    {/* Cold Icon: 4+ Consecutive Misses */}
+    {player.shots_missed_in_row >= 4 && (
+      <span className={styles.coldIcon}>
+        <FaSnowflake />
+      </span>
+    )}
+  </>
+);
+
 
 // Function to calculate the current streak of consecutive made shots
 const calculateShotsMadeInRow = async (playerInstanceId: number) => {
@@ -754,6 +779,7 @@ const StandingsPage: React.FC = () => {
                             }}
                           >
                             <span className={styles.playerNameText}>{player.name}</span>
+                            <PlayerStatusIcons player={player} />
                           </div>
                         </div>
                         <span className={styles.totalPoints}>{player.player_score}</span>
@@ -793,27 +819,7 @@ const StandingsPage: React.FC = () => {
                         }}
                       >
                         <span className={styles.playerNameText}>{player.name}</span>
-                        {player.name === 'A. Begy' && (
-                          <span className={styles.crownIcon}>👑</span>
-                        )}
-                        {player.shots_left % 10 === 1 && (
-                          <span className={styles.moneyballIcon} aria-label="Moneyball shot">
-                            <FaDollarSign />
-                          </span>
-                        )}
-                        {/* Fire Icon: 3+ Consecutive Makes */}
-                        {player.shots_made_in_row >= 3 && (
-                          <span className={styles.fireIcon}>
-                            <FlameIcon />
-                          </span>
-                        )}
-
-                        {/* Cold Icon: 4+ Consecutive Misses */}
-                        {player.shots_missed_in_row >= 4 && (
-                          <span className={styles.coldIcon}>
-                            <FaSnowflake />
-                          </span>
-                        )}
+                        <PlayerStatusIcons player={player} />
                       </div>
                   </div>
                     {/* Player Stats */}


### PR DESCRIPTION
### Motivation
- The modern Standings / Free For All UI update introduced a separate FFA row template that omitted the player status icon block, causing valid per-player streaks (fire/cold) to not be displayed in FFA mode.
- The fix must be minimal, preserve existing streak rules and the refreshed UI, and ensure streaks are still computed per player instance (not per team).

### Description
- Added a small shared `PlayerStatusIcons` React helper and used it in both the normal team rows and the Free For All rows so both views render the same badges (crown, moneyball, fire, cold).
- Kept the existing streak calculation logic and thresholds untouched (`shots_made_in_row >= 3` for fire and `shots_missed_in_row >= 4` for cold) and did not modify any backend/database behavior.
- Applied the change in `src/app/Standings/page.tsx` by replacing duplicated JSX with the new helper and adding the helper to the FFA row rendering.

### Testing
- Ran `npm run lint`, which completed successfully (with unrelated hook-dependency warnings still present) and reported no blocking errors.
- Ran `npm run build`, which completed successfully and produced a successful Next.js production build (non-blocking Next.js advisories only).
- Manual validation ensured that the same `shots_made_in_row` / `shots_missed_in_row` fields computed by existing code now produce visible fire/cold icons in both normal team and Free For All leaderboards.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8e12de740832e8f9e8905b98d267d)