### PR TITLE
Remove duplicate fetchShotHistory on shot events

### DIFF
--- a/src/app/Standings/page.tsx
+++ b/src/app/Standings/page.tsx
@@ -662,9 +662,6 @@ const StandingsPage: React.FC = () => {
               }
               await fetchTeamsAndPlayers();
               await updateTeamScores();
-              if (season.season_id !== -1) {
-                await fetchShotHistory(season.season_id);
-              }
             } catch (error) {
               console.error('Error processing shot change:', error);
             }


### PR DESCRIPTION
### Motivation
- Prevent redundant shot-history loading when a shot event triggers both `fetchTeamsAndPlayers()` and a separate `fetchShotHistory(...)` call in the realtime shots handler.

### Description
- Removed the direct `await fetchShotHistory(season.season_id);` invocation from the `shots` realtime subscription callback in `src/app/Standings/page.tsx` and kept the single authoritative `await fetchShotHistory(activeSeasonId);` inside `fetchTeamsAndPlayers()`.

### Testing
- Ran code checks and validations including `rg -n "fetchShotHistory\(|shotChannel|fetchTeamsAndPlayers" src/app/Standings/page.tsx`, inspected the change with `git diff -- src/app/Standings/page.tsx`, committed the update with `git commit`, and created the PR; all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa19cd46c8832e8279205971e836cd)