### PR TITLE
Add single-shot leaderboard flow (server RPC + client integration)

### DIFF
--- a/src/app/Standings/page.tsx
+++ b/src/app/Standings/page.tsx
@@ -13,13 +13,6 @@ import monstarsLogo from '@/assets/images/Monstars - Clear BG.png';
 import nightmaresLogo from '@/assets/images/Nightmares - Clear BG Needs Fixed.png';
 import spartansLogo from '@/assets/images/Spartans-hoodie-illustrated-transparent-small.png';
 
-interface Team {
-  team_id: number;
-  team_name: string;
-  team_score: number;
-  is_hidden?: boolean;
-}
-
 interface TeamWithPlayers {
   team_id?: number;
   team_name: string;
@@ -54,6 +47,24 @@ interface ShotFeedItem {
   player_name: string;
   tier_name: string | null;
   tier_color: string | null;
+}
+
+
+interface LeaderboardRow {
+  team_id: number;
+  team_name: string;
+  player_id: number;
+  player_instance_id: number;
+  player_name: string;
+  player_score: number;
+  shots_left: number;
+  shots_left_dashes: number;
+  shots_taken: number;
+  pps: number;
+  tier_color: string | null;
+  shots_made_in_row: number;
+  shots_missed_in_row: number;
+  reached_score_at: string | null;
 }
 
 const teamLogoMap: Record<string, StaticImageData> = {
@@ -159,91 +170,6 @@ const PlayerStatusIcons: React.FC<{ player: TeamWithPlayers['players'][number] }
 );
 
 
-// Function to calculate the current streak of consecutive made shots
-const calculateShotsMadeInRow = async (playerInstanceId: number) => {
-  try {
-    const { data: shots, error: shotsError } = await supabase
-      .from('shots')
-      .select('result')
-      .eq('instance_id', playerInstanceId)
-      .order('shot_date', { ascending: true });
-
-    if (shotsError || !shots) throw shotsError;
-
-    // Walk backwards from the most recent shot
-    let makeStreak = 0;
-    for (let i = shots.length - 1; i >= 0; i--) {
-      if (shots[i].result !== 0) {
-        makeStreak++;
-      } else {
-        break;
-      }
-    }
-
-    return makeStreak;
-  } catch (error) {
-    console.error('Error calculating shots made in a row:', error);
-    return 0;
-  }
-};
-
-
-const calculateShotDetails = async (
-  playerInstanceId: number,
-  targetScore: number,
-) => {
-  try {
-    const { data: shots, error: shotsError } = await supabase
-      .from('shots')
-      .select('result, shot_date')
-      .eq('instance_id', playerInstanceId)
-      .order('shot_date', { ascending: true });
-
-    if (shotsError || !shots) throw shotsError;
-
-    let makeStreak = 0;
-    let missStreak = 0;
-    let cumulativeScore = 0;
-    let reachedScoreAt: string | null = null;
-
-    for (let i = shots.length - 1; i >= 0; i--) {
-      const shotResult = Number(shots[i].result) || 0;
-      if (shotResult !== 0) {
-        makeStreak++;
-      } else {
-        break;
-      }
-    }
-
-    for (let i = shots.length - 1; i >= 0; i--) {
-      const shotResult = Number(shots[i].result) || 0;
-      if (shotResult === 0) {
-        missStreak++;
-      } else {
-        break;
-      }
-    }
-
-    shots.forEach((shot) => {
-      const shotResult = Number(shot.result) || 0;
-      cumulativeScore += shotResult;
-      if (!reachedScoreAt && cumulativeScore >= targetScore) {
-        reachedScoreAt = shot.shot_date;
-      }
-    });
-
-    return {
-      shotsMadeInRow: makeStreak,
-      shotsMissedInRow: missStreak,
-      reachedScoreAt,
-    };
-  } catch (error) {
-    console.error('Error calculating shot details:', error);
-    return { shotsMadeInRow: 0, shotsMissedInRow: 0, reachedScoreAt: null };
-  }
-};
-
-
 const StandingsPage: React.FC = () => {
  // State variables
  const [teams, setTeams] = useState<TeamWithPlayers[]>([]); // Stores the list of teams and their players
@@ -261,6 +187,9 @@ const StandingsPage: React.FC = () => {
  const router = useRouter(); // Router for navigation
  const hasInitializedRef = useRef(false);
  const isRealtimeSubscribingRef = useRef(false);
+ const refreshDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+ const refreshInFlightRef = useRef(false);
+ const refreshQueuedRef = useRef(false);
  const isFfaSeason = season.season_name.toLowerCase().includes('ffa')
   || season.season_name.toLowerCase().includes('free for all');
  const isFfaTeam = (teamName: string) => teamName === 'Free For All';
@@ -345,7 +274,6 @@ const StandingsPage: React.FC = () => {
   const fetchTeamsAndPlayers = useCallback(async () => {
     try {
       setIsLoading(true);
-            // Fetch active season details
 
       const { data: activeSeason, error: seasonError } = await supabase
         .from('seasons')
@@ -357,104 +285,78 @@ const StandingsPage: React.FC = () => {
       if (!activeSeason) {
         setSeason({ season_id: -1, season_name: 'No Active Season', shot_total: 0, rules: '' });
         setTeams([]);
+        setRecentShots([]);
         return;
       }
 
-      const activeSeasonId = activeSeason.season_id;
       setSeason(activeSeason);
-      await fetchShotHistory(activeSeasonId);
-        // Fetch teams
+      await fetchShotHistory(activeSeason.season_id);
 
-      const { data: teamsData, error: teamsError } = await supabase
-        .from('teams')
-        .select('team_name, team_id, is_hidden');
+      const { data: leaderboardRows, error: leaderboardError } = await supabase
+        .rpc('get_leaderboard', { p_season_id: activeSeason.season_id });
 
-      if (teamsError) throw teamsError;
-      const visibleTeams = (teamsData || []).filter((team) => !team.is_hidden);
-        // Enrich teams with their players and stats
+      if (leaderboardError) throw leaderboardError;
 
-      const teamsWithPlayers: TeamWithPlayers[] = await Promise.all(
-        visibleTeams.map(async (team: any) => {
-          const { data: players, error: playersError } = await supabase
-            .from('players')
-            .select('*, tiers(color)')
-            .eq('team_id', team.team_id);
-          if (playersError) throw playersError;
+      const teamsById = new Map<number, TeamWithPlayers>();
 
-          const visiblePlayers = (players || []).filter((player: any) => !player.is_hidden);
+      (leaderboardRows ?? []).forEach((row: LeaderboardRow) => {
+        const team = teamsById.get(row.team_id) ?? {
+          team_id: row.team_id,
+          team_name: row.team_name,
+          players: [],
+          team_pps: 0,
+          total_shots: 0,
+          team_score: 0,
+        };
 
-          const playersWithStats = await Promise.all(
-            visiblePlayers.map(async (player: any) => {
-              const { data: playerInstance, error: piError } = await supabase
-                .from('player_instance')
-                .select('player_instance_id, shots_left, shots_left_dashes, score')
-                .eq('player_id', player.player_id)
-                .eq('season_id', activeSeasonId)
-                .single();
+        team.players.push({
+          name: row.player_name,
+          shots_left: Number(row.shots_left) || 0,
+          shots_left_dashes: Math.max(0, Math.min(2, Number(row.shots_left_dashes) || 0)),
+          player_score: Number(row.player_score) || 0,
+          shots_taken: Number(row.shots_taken) || 0,
+          pps: Number(row.pps) || 0,
+          tier_color: row.tier_color || '#000',
+          shots_made_in_row: Number(row.shots_made_in_row) || 0,
+          shots_missed_in_row: Number(row.shots_missed_in_row) || 0,
+          reached_score_at: row.reached_score_at,
+        });
 
-              if (piError || !playerInstance) throw piError;
-              // Calculate streaks
+        teamsById.set(row.team_id, team);
+      });
 
-              const { shotsMadeInRow, shotsMissedInRow, reachedScoreAt } = await calculateShotDetails(
-                playerInstance.player_instance_id,
-                playerInstance.score,
-              );
-              console.log(shotsMadeInRow, shotsMissedInRow);
-              const shotsTaken = Math.max(0, activeSeason.shot_total - playerInstance.shots_left);
-              const shotsLeftDashes = Math.max(0, Math.min(2, playerInstance.shots_left_dashes ?? 0));
-              return {
-                name: player.name,
-                shots_left: playerInstance.shots_left,
-                shots_left_dashes: shotsLeftDashes,
-                player_score: playerInstance.score,
-                shots_taken: shotsTaken,
-                pps: shotsTaken > 0 ? playerInstance.score / shotsTaken : 0,
-                tier_color: player.tiers?.color || '#000',
-                shots_made_in_row: shotsMadeInRow,
-                shots_missed_in_row: shotsMissedInRow,
-                reached_score_at: reachedScoreAt,
-              };
-            })
-          );
+      const teamsWithPlayers = Array.from(teamsById.values()).map((team) => {
+        team.players.sort((a, b) => {
+          if (b.player_score !== a.player_score) {
+            return b.player_score - a.player_score;
+          }
 
-          // Sort players by their score, descending. Break ties with PPS and then by who reached the score first.
-          playersWithStats.sort((a, b) => {
-            if (b.player_score !== a.player_score) {
-              return b.player_score - a.player_score;
-            }
+          if (b.pps !== a.pps) {
+            return b.pps - a.pps;
+          }
 
-            if (b.pps !== a.pps) {
-              return b.pps - a.pps;
-            }
+          const aReachedScoreAt = a.reached_score_at ? new Date(a.reached_score_at).getTime() : Infinity;
+          const bReachedScoreAt = b.reached_score_at ? new Date(b.reached_score_at).getTime() : Infinity;
 
-            const aReachedScoreAt = a.reached_score_at ? new Date(a.reached_score_at).getTime() : Infinity;
-            const bReachedScoreAt = b.reached_score_at ? new Date(b.reached_score_at).getTime() : Infinity;
+          if (aReachedScoreAt !== bReachedScoreAt) {
+            return aReachedScoreAt - bReachedScoreAt;
+          }
 
-            if (aReachedScoreAt !== bReachedScoreAt) {
-              return aReachedScoreAt - bReachedScoreAt;
-            }
+          return a.name.localeCompare(b.name);
+        });
 
-            return a.name.localeCompare(b.name);
-          });
-          // Calculate total shots left for the team
+        const totalShots = team.players.reduce((acc, player) => acc + player.shots_left, 0);
+        const totalShotsTaken = team.players.reduce((acc, player) => acc + player.shots_taken, 0);
+        const teamScore = team.players.reduce((acc, player) => acc + player.player_score, 0);
 
-          const totalShots = playersWithStats.reduce((acc, player) => acc + player.shots_left, 0);
-          const totalShotsTaken = playersWithStats.reduce((acc, player) => acc + player.shots_taken, 0);
-          const teamScore = playersWithStats.reduce((acc, player) => acc + player.player_score, 0);
-          const teamPointsPerShot = totalShotsTaken > 0 ? teamScore / totalShotsTaken : 0;
+        return {
+          ...team,
+          team_pps: totalShotsTaken > 0 ? teamScore / totalShotsTaken : 0,
+          total_shots: totalShots,
+          team_score: teamScore,
+        };
+      });
 
-          return {
-            team_id: team.team_id,
-            team_name: team.team_name,
-            players: playersWithStats,
-            team_pps: teamPointsPerShot,
-            total_shots: totalShots,
-            team_score: teamScore,
-          };
-        })
-      );
-  
-      // Sort the teams by team_score in descending order
       teamsWithPlayers.sort((a, b) => b.team_score - a.team_score);
       setTeams(teamsWithPlayers);
     } catch (error) {
@@ -462,7 +364,7 @@ const StandingsPage: React.FC = () => {
     } finally {
       setIsLoading(false);
     }
-  }, []);
+  }, [fetchShotHistory]);
 
   // useEffect(() => {
   //   // Function to unlock and keep AudioContext alive
@@ -522,12 +424,36 @@ const StandingsPage: React.FC = () => {
  /**
    * Subscribes to user view changes in real time and updates state accordingly.
    */
-  const refreshStandings = useCallback(async (seasonId?: number) => {
-    await fetchTeamsAndPlayers();
-    if (seasonId && seasonId !== -1) {
-      await fetchShotHistory(seasonId);
+  const refreshStandings = useCallback(async () => {
+    if (refreshInFlightRef.current) {
+      refreshQueuedRef.current = true;
+      return;
     }
-  }, [fetchTeamsAndPlayers, fetchShotHistory]);
+
+    refreshInFlightRef.current = true;
+
+    try {
+      await fetchTeamsAndPlayers();
+    } finally {
+      refreshInFlightRef.current = false;
+
+      if (refreshQueuedRef.current) {
+        refreshQueuedRef.current = false;
+        await refreshStandings();
+      }
+    }
+  }, [fetchTeamsAndPlayers]);
+
+  const queueStandingsRefresh = useCallback(() => {
+    if (refreshDebounceRef.current) {
+      clearTimeout(refreshDebounceRef.current);
+    }
+
+    refreshDebounceRef.current = setTimeout(() => {
+      refreshDebounceRef.current = null;
+      refreshStandings();
+    }, 350);
+  }, [refreshStandings]);
 
   useEffect(() => {
     let userViewChannel: ReturnType<typeof supabase.channel> | null = null;
@@ -560,6 +486,10 @@ const StandingsPage: React.FC = () => {
       if (userViewChannel) {
         supabase.removeChannel(userViewChannel);
       }
+      if (refreshDebounceRef.current) {
+        clearTimeout(refreshDebounceRef.current);
+        refreshDebounceRef.current = null;
+      }
       hasInitializedRef.current = false;
     };
   }, [refreshStandings]);
@@ -570,43 +500,23 @@ const StandingsPage: React.FC = () => {
 
     const playerInstanceChannel = supabase
       .channel('player-instance-db-changes')
-      .on('postgres_changes', { event: '*', schema: 'public', table: 'player_instance' }, async () => {
-        await refreshStandings();
-      })
+      .on('postgres_changes', { event: 'INSERT', schema: 'public', table: 'player_instance' }, queueStandingsRefresh)
+      .on('postgres_changes', { event: 'DELETE', schema: 'public', table: 'player_instance' }, queueStandingsRefresh)
       .subscribe();
 
     const teamChannel = supabase
       .channel('team-db-changes')
-      .on('postgres_changes', { event: '*', schema: 'public', table: 'teams' }, async () => {
-        await refreshStandings();
-      })
+      .on('postgres_changes', { event: '*', schema: 'public', table: 'teams' }, queueStandingsRefresh)
       .subscribe();
 
     const playerChannel = supabase
       .channel('player-db-changes')
-      .on('postgres_changes', { event: '*', schema: 'public', table: 'players' }, async () => {
-        await refreshStandings();
-      })
+      .on('postgres_changes', { event: '*', schema: 'public', table: 'players' }, queueStandingsRefresh)
       .subscribe();
 
     const shotChannel = supabase
       .channel('shots-db-changes')
-      .on('postgres_changes', { event: '*', schema: 'public', table: 'shots' }, async (payload) => {
-        try {
-          const newRow = payload.new as { result: number; instance_id: number };
-          const { result, instance_id } = newRow;
-
-          if (result !== 0) {
-            const newStreak = await calculateShotsMadeInRow(instance_id);
-            if (newStreak === 3) {
-              // sound.play();
-            }
-          }
-          await refreshStandings(season.season_id);
-        } catch (error) {
-          console.error('Error processing shot change:', error);
-        }
-      })
+      .on('postgres_changes', { event: 'INSERT', schema: 'public', table: 'shots' }, queueStandingsRefresh)
       .subscribe();
 
     return () => {
@@ -616,7 +526,7 @@ const StandingsPage: React.FC = () => {
       supabase.removeChannel(shotChannel);
       isRealtimeSubscribingRef.current = false;
     };
-  }, [refreshStandings, season.season_id]);
+  }, [queueStandingsRefresh]);
 
  return (
   <div className={styles.userContainer}>

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -11,6 +11,17 @@ interface ModalProps {
   playerId: number; // Player ID associated with the modal
 }
 
+
+interface RecordedShotResult {
+  score: number;
+  shots_left: number;
+  shots_left_dashes: number;
+  shots_taken_today: number;
+  todays_score: number;
+  current_make_streak: number;
+  current_miss_streak: number;
+}
+
 /**
  * Modal Component
  * 
@@ -72,63 +83,6 @@ const Modal: React.FC<ModalProps> = ({ name, isOpen, onClose, playerId }) => {
     setTodaysScore(null);
     setUseDash(false);
   };
-  const calculateShotsMadeInRow = async (playerInstanceId: number) => {
-    try {
-      const { data: shots, error: shotsError } = await supabase
-        .from('shots')
-        .select('result')
-        .eq('instance_id', playerInstanceId)
-        .order('shot_date', { ascending: true });
-  
-      if (shotsError || !shots) throw shotsError;
-  
-      let currentStreak = 0;
-  
-      for (let i = shots.length - 1; i >= 0; i--) {
-        const result = Number(shots[i].result);
-        if (result !== 0) {
-          currentStreak++;
-        } else {
-          break;
-        }
-      }
-  
-      return currentStreak;
-    } catch (error) {
-      console.error('Error calculating shots made in a row:', error);
-      return 0;
-    }
-  };
-  
-  
-
-  const calculateShotsMissedInRow = async (playerInstanceId: number) => {
-    try {
-      const { data: shots, error: shotsError } = await supabase
-        .from('shots')
-        .select('result')
-        .eq('instance_id', playerInstanceId)
-        .order('shot_date', { ascending: true });
-  
-      if (shotsError || !shots) throw shotsError;
-  
-      let missStreak = 0;
-  
-      for (let i = shots.length - 1; i >= 0; i--) {
-        const result = Number(shots[i].result);
-        if (result === 0) {
-          missStreak++;
-        } else {
-          break;
-        }
-      }
-  
-      return missStreak;
-    } catch (error) {
-      return 0;
-    }
-  };
-  
   /**
    * Plays a notification sound when a shot is successfully recorded.
    */
@@ -300,42 +254,33 @@ const Modal: React.FC<ModalProps> = ({ name, isOpen, onClose, playerId }) => {
     if (isMoneyball) finalPoints *= 2;
     if (isDouble) finalPoints *= 2;
   
-    const shotId = parseInt(`${Date.now()}${Math.floor(Math.random() * 1000)}`.slice(-9), 10);
-  
     try {
-      const { error: shotError } = await supabase.from('shots').insert({
-        instance_id: playerInstanceId,
-        shot_date: new Date().toISOString(),
-        result: finalPoints,
-        tier_id: tierId,
-        shot_id: shotId,
-      });
-  
-      if (shotError) {
-        console.error('Error recording shot:', shotError);
-        return;
-      }
-  
-      const newScore = currentScore + finalPoints;
-      const newShotsLeft = (shotsLeft || 0) - 1;
-      const nextShotsLeftDashes = Math.max(0, (shotsLeftDashes ?? 0) - (useDash ? 1 : 0));
-
-      const { error: updateScoreError } = await supabase
-        .from('player_instance')
-        .update({
-          score: newScore,
-          shots_left: newShotsLeft,
-          shots_left_dashes: nextShotsLeftDashes,
+      const { data: recordedShot, error: recordShotError } = await supabase
+        .rpc('record_shot', {
+          p_instance_id: playerInstanceId,
+          p_tier_id: tierId,
+          p_result: finalPoints,
+          p_use_dash: useDash,
         })
-        .eq('player_instance_id', playerInstanceId);
+        .single();
   
-      if (updateScoreError) {
-        console.error('Error updating player:', updateScoreError);
+      if (recordShotError || !recordedShot) {
+        console.error('Error recording shot:', recordShotError);
         return;
       }
   
-      const newStreak = await calculateShotsMadeInRow(playerInstanceId);
-      const missStreak = await calculateShotsMissedInRow(playerInstanceId);
+      const shotResult = recordedShot as RecordedShotResult;
+      const updatedScore = Number(shotResult.score) || 0;
+      const updatedShotsLeft = Number(shotResult.shots_left) || 0;
+      const updatedShotsLeftDashes = Number(shotResult.shots_left_dashes) || 0;
+      const newStreak = Number(shotResult.current_make_streak) || 0;
+      const missStreak = Number(shotResult.current_miss_streak) || 0;
+
+      setCurrentScore(updatedScore);
+      setShotsLeft(updatedShotsLeft);
+      setShotsLeftDashes(updatedShotsLeftDashes);
+      setShotsTakenToday(Number(shotResult.shots_taken_today) || 0);
+      setTodaysScore(Number(shotResult.todays_score) || 0);
   
       if (missStreak === 4) {
         sadsound.play();
@@ -353,9 +298,6 @@ const Modal: React.FC<ModalProps> = ({ name, isOpen, onClose, playerId }) => {
           }
         }
       }
-
-      setShotsTakenToday((prev) => (prev !== null ? prev + 1 : null));
-      setTodaysScore((prev) => (prev !== null ? prev + finalPoints : null));
 
       handleClose();
     } catch (error) {

--- a/supabase/migrations/20260505120000_single_shot_leaderboard_flow.sql
+++ b/supabase/migrations/20260505120000_single_shot_leaderboard_flow.sql
@@ -1,0 +1,232 @@
+-- Record shots and refresh standings through a single server-side path.
+
+-- Ensure shots can be inserted without client-generated identifiers.
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'S'
+      AND n.nspname = 'public'
+      AND c.relname = 'shots_shot_id_seq'
+  ) THEN
+    CREATE SEQUENCE public.shots_shot_id_seq OWNED BY public.shots.shot_id;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'shots'
+      AND column_name = 'shot_id'
+      AND is_identity = 'NO'
+      AND column_default IS NULL
+  ) THEN
+    ALTER TABLE public.shots ALTER COLUMN shot_id SET DEFAULT nextval('public.shots_shot_id_seq');
+  END IF;
+
+  PERFORM setval(
+    'public.shots_shot_id_seq',
+    GREATEST(COALESCE((SELECT max(shot_id) FROM public.shots), 0), 1),
+    COALESCE((SELECT max(shot_id) FROM public.shots), 0) > 0
+  );
+END $$;
+
+CREATE OR REPLACE FUNCTION public.record_shot(
+  p_instance_id integer,
+  p_tier_id integer,
+  p_result integer,
+  p_use_dash boolean DEFAULT false
+)
+RETURNS TABLE (
+  shot_id integer,
+  shot_date timestamptz,
+  player_instance_id integer,
+  score integer,
+  shots_left integer,
+  shots_left_dashes integer,
+  shots_taken_today integer,
+  todays_score integer,
+  current_make_streak integer,
+  current_miss_streak integer
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  inserted_shot public.shots%ROWTYPE;
+  updated_player public.player_instance%ROWTYPE;
+BEGIN
+  INSERT INTO public.shots (instance_id, shot_date, result, tier_id)
+  VALUES (p_instance_id, now(), p_result::text, p_tier_id)
+  RETURNING * INTO inserted_shot;
+
+  UPDATE public.player_instance pi
+  SET
+    score = COALESCE(pi.score, 0) + p_result,
+    shots_left = GREATEST(COALESCE(pi.shots_left, 0) - 1, 0),
+    shots_left_dashes = GREATEST(COALESCE(pi.shots_left_dashes, 0) - CASE WHEN p_use_dash THEN 1 ELSE 0 END, 0)
+  WHERE pi.player_instance_id = p_instance_id
+  RETURNING * INTO updated_player;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'Player instance % not found', p_instance_id USING ERRCODE = 'P0002';
+  END IF;
+
+  RETURN QUERY
+  WITH ordered_shots AS (
+    SELECT
+      s.result::integer AS shot_result,
+      bool_or(s.result::integer = 0) OVER (
+        ORDER BY s.shot_date DESC NULLS LAST, s.shot_id DESC
+        ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING
+      ) AS had_newer_miss,
+      bool_or(s.result::integer <> 0) OVER (
+        ORDER BY s.shot_date DESC NULLS LAST, s.shot_id DESC
+        ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING
+      ) AS had_newer_make
+    FROM public.shots s
+    WHERE s.instance_id = p_instance_id
+  ), todays_shots AS (
+    SELECT
+      count(*)::integer AS shots_taken_today,
+      COALESCE(sum(s.result::integer), 0)::integer AS todays_score
+    FROM public.shots s
+    WHERE s.instance_id = p_instance_id
+      AND s.shot_date >= date_trunc('day', now())
+      AND s.shot_date < date_trunc('day', now()) + interval '1 day'
+  )
+  SELECT
+    inserted_shot.shot_id,
+    inserted_shot.shot_date::timestamptz,
+    updated_player.player_instance_id,
+    COALESCE(updated_player.score, 0),
+    COALESCE(updated_player.shots_left, 0),
+    COALESCE(updated_player.shots_left_dashes, 0),
+    todays_shots.shots_taken_today,
+    todays_shots.todays_score,
+    COALESCE(count(*) FILTER (WHERE ordered_shots.shot_result <> 0 AND NOT COALESCE(ordered_shots.had_newer_miss, false)), 0)::integer AS current_make_streak,
+    COALESCE(count(*) FILTER (WHERE ordered_shots.shot_result = 0 AND NOT COALESCE(ordered_shots.had_newer_make, false)), 0)::integer AS current_miss_streak
+  FROM todays_shots
+  LEFT JOIN ordered_shots ON true
+  GROUP BY
+    todays_shots.shots_taken_today,
+    todays_shots.todays_score;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.get_leaderboard(p_season_id integer)
+RETURNS TABLE (
+  team_id integer,
+  team_name text,
+  player_id integer,
+  player_instance_id integer,
+  player_name text,
+  player_score integer,
+  shots_left integer,
+  shots_left_dashes integer,
+  shots_taken integer,
+  pps numeric,
+  tier_color text,
+  shots_made_in_row integer,
+  shots_missed_in_row integer,
+  reached_score_at timestamptz
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+  WITH season_row AS (
+    SELECT s.season_id, s.shot_total
+    FROM public.seasons s
+    WHERE s.season_id = p_season_id
+  ), visible_players AS (
+    SELECT
+      t.team_id,
+      t.team_name,
+      p.player_id,
+      p.name AS player_name,
+      pi.player_instance_id,
+      COALESCE(pi.score, 0) AS player_score,
+      COALESCE(pi.shots_left, 0) AS shots_left,
+      GREATEST(0, LEAST(2, COALESCE(pi.shots_left_dashes, 0))) AS shots_left_dashes,
+      GREATEST(0, COALESCE(sr.shot_total, 0) - COALESCE(pi.shots_left, 0)) AS shots_taken,
+      COALESCE(tiers.color, '#000') AS tier_color
+    FROM season_row sr
+    JOIN public.player_instance pi ON pi.season_id = sr.season_id
+    JOIN public.players p ON p.player_id = pi.player_id
+    JOIN public.teams t ON t.team_id = p.team_id
+    LEFT JOIN public.tiers ON tiers.tier_id = p.tier_id
+    WHERE COALESCE(p.is_hidden, false) = false
+      AND COALESCE(t.is_hidden, false) = false
+  ), ordered_shots AS (
+    SELECT
+      s.instance_id,
+      s.shot_date,
+      s.shot_id,
+      s.result::integer AS shot_result,
+      sum(s.result::integer) OVER (
+        PARTITION BY s.instance_id
+        ORDER BY s.shot_date ASC NULLS LAST, s.shot_id ASC
+      ) AS cumulative_score,
+      bool_or(s.result::integer = 0) OVER (
+        PARTITION BY s.instance_id
+        ORDER BY s.shot_date DESC NULLS LAST, s.shot_id DESC
+        ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING
+      ) AS had_newer_miss,
+      bool_or(s.result::integer <> 0) OVER (
+        PARTITION BY s.instance_id
+        ORDER BY s.shot_date DESC NULLS LAST, s.shot_id DESC
+        ROWS BETWEEN UNBOUNDED PRECEDING AND 1 PRECEDING
+      ) AS had_newer_make
+    FROM public.shots s
+    JOIN visible_players vp ON vp.player_instance_id = s.instance_id
+  ), shot_stats AS (
+    SELECT
+      vp.player_instance_id,
+      COALESCE(count(*) FILTER (WHERE os.shot_result <> 0 AND NOT COALESCE(os.had_newer_miss, false)), 0)::integer AS shots_made_in_row,
+      COALESCE(count(*) FILTER (WHERE os.shot_result = 0 AND NOT COALESCE(os.had_newer_make, false)), 0)::integer AS shots_missed_in_row,
+      min(os.shot_date) FILTER (WHERE os.cumulative_score >= vp.player_score AND vp.player_score > 0) AS reached_score_at
+    FROM visible_players vp
+    LEFT JOIN ordered_shots os ON os.instance_id = vp.player_instance_id
+    GROUP BY vp.player_instance_id
+  )
+  SELECT
+    vp.team_id,
+    vp.team_name,
+    vp.player_id,
+    vp.player_instance_id,
+    vp.player_name,
+    vp.player_score,
+    vp.shots_left,
+    vp.shots_left_dashes,
+    vp.shots_taken,
+    CASE WHEN vp.shots_taken > 0 THEN vp.player_score::numeric / vp.shots_taken ELSE 0 END AS pps,
+    vp.tier_color,
+    COALESCE(ss.shots_made_in_row, 0) AS shots_made_in_row,
+    COALESCE(ss.shots_missed_in_row, 0) AS shots_missed_in_row,
+    ss.reached_score_at
+  FROM visible_players vp
+  LEFT JOIN shot_stats ss ON ss.player_instance_id = vp.player_instance_id
+  ORDER BY
+    vp.team_name ASC,
+    vp.player_score DESC,
+    CASE WHEN vp.shots_taken > 0 THEN vp.player_score::numeric / vp.shots_taken ELSE 0 END DESC,
+    ss.reached_score_at ASC NULLS LAST,
+    vp.player_name ASC;
+$$;
+
+CREATE INDEX IF NOT EXISTS shots_instance_id_shot_date_desc_idx
+  ON public.shots (instance_id, shot_date DESC, shot_id DESC);
+
+CREATE INDEX IF NOT EXISTS player_instance_season_id_player_id_idx
+  ON public.player_instance (season_id, player_id);
+
+CREATE INDEX IF NOT EXISTS players_team_id_idx
+  ON public.players (team_id);
+
+CREATE INDEX IF NOT EXISTS seasons_end_date_idx
+  ON public.seasons (end_date);


### PR DESCRIPTION
### Motivation

- Avoid double-refreshes and expensive client-side per-player `shots` queries by making shot recording a single atomic server operation that returns all UI-needed values.  
- Move leaderboard aggregation to the database so the client can fetch a single flat leaderboard result instead of nested per-player queries.  

### Description

- Added a new Supabase migration `supabase/migrations/20260505120000_single_shot_leaderboard_flow.sql` that creates a server-side RPC `record_shot(instance_id, tier_id, result, use_dash)` which inserts into `public.shots`, atomically updates `public.player_instance` (score, `shots_left`, `shots_left_dashes`), and returns the inserted `shot_id`, updated player totals, today totals, and streak counts; the migration also ensures server-side `shot_id` sequencing and adds `get_leaderboard(p_season_id)` to produce flat leaderboard rows and supporting indexes (`shots(instance_id, shot_date desc)`, `player_instance(season_id, player_id)`, `players(team_id)`, `seasons(end_date)`).  
- Replaced client two-step write logic in `src/components/Modal/Modal.tsx` with a single RPC call `supabase.rpc('record_shot', ...)`, consuming the returned totals/streaks to update local state and preserve existing notification/streak UX; removed redundant client-side full-table streak queries.  
- Reworked `src/app/Standings/page.tsx` to use the server-side `get_leaderboard` RPC in `fetchTeamsAndPlayers()` (mapping flat rows into `TeamWithPlayers[]`), fetch shot history once per refresh with `fetchShotHistory()`, and eliminate per-player `shots` queries.  
- Changed realtime subscriptions to reduce duplicate refreshes: player-instance channel listens only for structural changes (INSERT/DELETE) rather than `event: '*'`, `shots` channel listens for `INSERT` only, and added a debounce/in-flight guard (`~350ms`) around `refreshStandings` so bursts collapse into one refresh.  
- Type additions to the client include `RecordedShotResult` and `LeaderboardRow` interfaces to model RPC responses.  

### Testing

- Ran `npm run lint` and addressed autofixable issues; lint completed with an existing unrelated warning in `src/app/Admin/page.tsx`.  
- Ran `npx tsc --noEmit` for type checking; the run surfaced pre-existing missing CSS/image module declaration errors across the repo that are unrelated to the changes in this PR (no new typed-property errors introduced by the RPC integration).  
- Ran `git diff --check` and basic project ESLint autofix commands during development to validate changes (no diff-check issues introduced by these edits).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa7825c0c8832ebb97b9237c9bf826)