### PR TITLE
Reduce shot history rerenders

### DIFF
--- a/src/app/Standings/page.tsx
+++ b/src/app/Standings/page.tsx
@@ -49,6 +49,31 @@ interface ShotFeedItem {
   tier_color: string | null;
 }
 
+interface ShotHistoryPanelProps {
+  recentShots: ShotFeedItem[];
+  isLoading: boolean;
+  error: string | null;
+  formatShotTime: (shotDate: string) => string;
+  formatShotResult: (result: number) => string;
+}
+
+const areShotFeedItemsEqual = (current: ShotFeedItem[], next: ShotFeedItem[]) => {
+  if (current.length !== next.length) return false;
+
+  return current.every((shot, index) => {
+    const nextShot = next[index];
+
+    return (
+      shot.shot_id === nextShot.shot_id
+      && shot.shot_date === nextShot.shot_date
+      && shot.result === nextShot.result
+      && shot.player_name === nextShot.player_name
+      && shot.tier_name === nextShot.tier_name
+      && shot.tier_color === nextShot.tier_color
+    );
+  });
+};
+
 
 interface LeaderboardRow {
   team_id: number;
@@ -169,6 +194,59 @@ const PlayerStatusIcons: React.FC<{ player: TeamWithPlayers['players'][number] }
   </>
 );
 
+const ShotHistoryPanel = React.memo(function ShotHistoryPanel({
+  recentShots,
+  isLoading,
+  error,
+  formatShotTime,
+  formatShotResult,
+}: ShotHistoryPanelProps) {
+  return (
+    <aside className={styles.shotHistoryPanel} aria-label="Live shot history">
+      <div className={styles.shotHistoryHeader}>
+        <h2 className={styles.shotHistoryTitle}>Shot History</h2>
+        <span className={styles.livePill}>Live</span>
+      </div>
+      <p className={styles.shotHistorySubtle}>Recent makes and misses for this season.</p>
+      {isLoading && (
+        <div className={styles.shotHistoryState}>Loading live feed…</div>
+      )}
+      {!isLoading && error && (
+        <div className={styles.shotHistoryState}>{error}</div>
+      )}
+      {!isLoading && !error && recentShots.length === 0 && (
+        <div className={styles.shotHistoryState}>
+          <strong>No shots recorded yet.</strong>
+          <span>Shot activity will appear here live.</span>
+        </div>
+      )}
+      {!isLoading && !error && recentShots.length > 0 && (
+        <ul className={styles.shotHistoryList}>
+          {recentShots.map((shot) => (
+            <li key={shot.shot_id} className={styles.shotHistoryItem}>
+              <div className={styles.shotTopRow}>
+                <div className={styles.shotPlayerWrap}>
+                  <span className={styles.shotPlayer}>{shot.player_name}</span>
+                  {shot.tier_color && (
+                    <span className={styles.tierChip} style={{ backgroundColor: shot.tier_color }}>
+                      {shot.tier_name || 'Tier'}
+                    </span>
+                  )}
+                </div>
+                <span className={`${styles.shotResult} ${shot.result > 0 ? styles.shotMade : styles.shotMiss}`}>
+                  {shot.result > 1 ? '🔥 ' : ''}{formatShotResult(shot.result)}
+                </span>
+              </div>
+              <div className={styles.shotMeta}>
+                {formatShotTime(shot.shot_date)}
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </aside>
+  );
+});
 
 const StandingsPage: React.FC = () => {
  // State variables
@@ -201,21 +279,23 @@ const StandingsPage: React.FC = () => {
  };
 
  const totalPlayers = useMemo(() => teams.reduce((acc, team) => acc + team.players.length, 0), [teams]);
- const formatShotTime = (shotDate: string) => {
+ const formatShotTime = useCallback((shotDate: string) => {
   const parsed = new Date(shotDate);
   if (Number.isNaN(parsed.getTime())) return 'Unknown time';
   return parsed.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' });
- };
+ }, []);
 
- const formatShotResult = (result: number) => {
+ const formatShotResult = useCallback((result: number) => {
   if (result > 0) return `+${result}`;
   if (result === 0) return 'Miss';
   return `${result}`;
- };
+ }, []);
 
- const fetchShotHistory = useCallback(async (seasonId: number) => {
+ const fetchShotHistory = useCallback(async (seasonId: number, showLoading = false) => {
   try {
-    setIsShotHistoryLoading(true);
+    if (showLoading) {
+      setIsShotHistoryLoading(true);
+    }
     setShotHistoryError(null);
     const { data, error } = await supabase
       .from('shots')
@@ -245,7 +325,9 @@ const StandingsPage: React.FC = () => {
       tier_color: shot.tiers?.color ?? null,
     }));
 
-    setRecentShots(mapped);
+    setRecentShots((currentShots) => (
+      areShotFeedItemsEqual(currentShots, mapped) ? currentShots : mapped
+    ));
   } catch (error) {
     console.error('Error fetching shot history:', error);
     setShotHistoryError('Unable to load live shot feed.');
@@ -695,49 +777,13 @@ const StandingsPage: React.FC = () => {
               })}
               </div>
             </section>
-            <aside className={styles.shotHistoryPanel} aria-label="Live shot history">
-              <div className={styles.shotHistoryHeader}>
-                <h2 className={styles.shotHistoryTitle}>Shot History</h2>
-                <span className={styles.livePill}>Live</span>
-              </div>
-              <p className={styles.shotHistorySubtle}>Recent makes and misses for this season.</p>
-              {isShotHistoryLoading && (
-                <div className={styles.shotHistoryState}>Loading live feed…</div>
-              )}
-              {!isShotHistoryLoading && shotHistoryError && (
-                <div className={styles.shotHistoryState}>{shotHistoryError}</div>
-              )}
-              {!isShotHistoryLoading && !shotHistoryError && recentShots.length === 0 && (
-                <div className={styles.shotHistoryState}>
-                  <strong>No shots recorded yet.</strong>
-                  <span>Shot activity will appear here live.</span>
-                </div>
-              )}
-              {!isShotHistoryLoading && !shotHistoryError && recentShots.length > 0 && (
-                <ul className={styles.shotHistoryList}>
-                  {recentShots.map((shot, index) => (
-                    <li key={`${shot.shot_id}-${index}`} className={styles.shotHistoryItem}>
-                      <div className={styles.shotTopRow}>
-                        <div className={styles.shotPlayerWrap}>
-                          <span className={styles.shotPlayer}>{shot.player_name}</span>
-                          {shot.tier_color && (
-                            <span className={styles.tierChip} style={{ backgroundColor: shot.tier_color }}>
-                              {shot.tier_name || 'Tier'}
-                            </span>
-                          )}
-                        </div>
-                        <span className={`${styles.shotResult} ${shot.result > 0 ? styles.shotMade : styles.shotMiss}`}>
-                          {shot.result > 1 ? '🔥 ' : ''}{formatShotResult(shot.result)}
-                        </span>
-                      </div>
-                      <div className={styles.shotMeta}>
-                        {formatShotTime(shot.shot_date)}
-                      </div>
-                    </li>
-                  ))}
-                </ul>
-              )}
-            </aside>
+            <ShotHistoryPanel
+              recentShots={recentShots}
+              isLoading={isShotHistoryLoading}
+              error={shotHistoryError}
+              formatShotTime={formatShotTime}
+              formatShotResult={formatShotResult}
+            />
           </div>
         </div>
     </main>


### PR DESCRIPTION
### Motivation
- The shot history list inside the Standings page was re-rendering on unrelated standings/team updates causing repeated styling/DOM updates for the recent-shot feed.

### Description
- Extracted the shot history UI into a memoized `ShotHistoryPanel` component and render it with stable props so unrelated parent renders skip the feed re-render when inputs are unchanged (`src/app/Standings/page.tsx`).
- Added `areShotFeedItemsEqual` to shallow-compare fetched feed arrays and only call `setRecentShots` when items actually change, and switched list keys to `shot_id` for stability.
- Stabilized `formatShotTime` and `formatShotResult` with `useCallback` and changed `fetchShotHistory` to accept `showLoading` so background refreshes do not toggle the loading state unnecessarily.

### Testing
- Ran `npm run lint` and the linter completed with a noted existing hook warning unrelated to these changes (passed).
- Ran `npm run build` and the Next.js production build completed successfully.
- Ran `npx tsc --noEmit` which surfaced pre-existing module declaration errors for CSS/module image imports but did not indicate type errors in the modified Standings code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa81eb0e60832eab6c2b9caccacf46)