### PR TITLE
Right-click deletes shots on Standings; remove visible delete button and context menu

### DIFF
--- a/src/app/Standings/StandingsPage.module.css
+++ b/src/app/Standings/StandingsPage.module.css
@@ -69,7 +69,6 @@
 .shotHistoryTitle { margin: 0; font-size: 1.2rem; font-weight: 800; color:#0f172a; }
 .livePill { background:#dcfce7; color:#166534; border-radius:999px; padding:4px 10px; font-size:.75rem; font-weight:800; letter-spacing:.05em; text-transform:uppercase; }
 .shotHistorySubtle { margin: 0 0 4px; color:#64748b; font-size:.92rem; }
-.shotHistoryInstruction { margin: 0 0 10px; color:#94a3b8; font-size:.78rem; }
 .shotDeleteStatus { border:1px solid #fecaca; border-radius:10px; padding:8px 10px; margin-bottom:10px; background:#fff1f2; color:#9f1239; font-size:.84rem; font-weight:700; }
 .shotHistoryState { border:1px dashed #cbd5e1; border-radius:12px; padding:14px; color:#475569; display:flex; flex-direction:column; gap:4px; }
 .shotHistoryList { list-style:none; margin:0; padding:0; overflow:auto; display:flex; flex-direction:column; gap:10px; }
@@ -84,13 +83,6 @@
 .shotMiss { color:#7f1d1d; }
 .shotMeta { color:#64748b; font-size:.84rem; }
 .shotMetaRow { margin-top:6px; display:flex; justify-content:space-between; align-items:center; gap:10px; }
-.shotRowDeleteButton { border:1px solid #fecaca; background:#fff; color:#b91c1c; border-radius:999px; padding:4px 9px; font-size:.74rem; font-weight:800; cursor:pointer; }
-.shotRowDeleteButton:hover, .shotRowDeleteButton:focus-visible { background:#fee2e2; color:#7f1d1d; outline:none; }
-.shotRowDeleteButton:disabled { cursor:not-allowed; opacity:.55; background:#f1f5f9; color:#64748b; border-color:#cbd5e1; }
-.shotContextMenu { position:fixed; z-index:1000; min-width:150px; padding:6px; border:1px solid #fecaca; border-radius:12px; background:#fff; box-shadow:0 18px 40px rgba(15,23,42,.22); }
-.shotContextDeleteButton { width:100%; border:none; border-radius:9px; padding:9px 10px; background:#fff; color:#b91c1c; text-align:left; font-weight:800; cursor:pointer; }
-.shotContextDeleteButton:hover, .shotContextDeleteButton:focus-visible { background:#fee2e2; color:#7f1d1d; outline:none; }
-.shotContextDeleteButton:disabled { cursor:not-allowed; opacity:.55; background:#f1f5f9; color:#64748b; }
 
 .team {
   display: flex;

--- a/src/app/Standings/page.tsx
+++ b/src/app/Standings/page.tsx
@@ -52,10 +52,6 @@ interface ShotFeedItem {
   tier_color: string | null;
 }
 
-interface ShotMenuPosition {
-  x: number;
-  y: number;
-}
 
 interface ShotHistoryPanelProps {
   recentShots: ShotFeedItem[];
@@ -63,11 +59,9 @@ interface ShotHistoryPanelProps {
   error: string | null;
   deleteStatus: string | null;
   deletingShotId: number | null;
-  selectedShotId: number | null;
   formatShotTime: (shotDate: string) => string;
   formatShotResult: (result: number) => string;
   onShotContextMenu: (event: React.MouseEvent<HTMLLIElement>, shot: ShotFeedItem) => void;
-  onRequestDeleteShot: (shot: ShotFeedItem) => void;
 }
 
 const areShotFeedItemsEqual = (current: ShotFeedItem[], next: ShotFeedItem[]) => {
@@ -304,11 +298,9 @@ const ShotHistoryPanel = React.memo(function ShotHistoryPanel({
   error,
   deleteStatus,
   deletingShotId,
-  selectedShotId,
   formatShotTime,
   formatShotResult,
   onShotContextMenu,
-  onRequestDeleteShot,
 }: ShotHistoryPanelProps) {
   return (
     <aside className={styles.shotHistoryPanel} aria-label="Live shot history">
@@ -317,7 +309,6 @@ const ShotHistoryPanel = React.memo(function ShotHistoryPanel({
         <span className={styles.livePill}>Live</span>
       </div>
       <p className={styles.shotHistorySubtle}>Recent makes and misses for this season.</p>
-      <p className={styles.shotHistoryInstruction}>Right-click a shot to delete, or use its Delete button.</p>
       {deleteStatus && (
         <div className={styles.shotDeleteStatus} role="status">{deleteStatus}</div>
       )}
@@ -338,7 +329,7 @@ const ShotHistoryPanel = React.memo(function ShotHistoryPanel({
           {recentShots.map((shot) => (
             <li
               key={shot.shot_id}
-              className={`${styles.shotHistoryItem} ${selectedShotId === shot.shot_id ? styles.shotHistoryItemSelected : ''}`}
+              className={`${styles.shotHistoryItem} ${deletingShotId === shot.shot_id ? styles.shotHistoryItemSelected : ''}`}
               onContextMenu={(event) => onShotContextMenu(event, shot)}
             >
               <div className={styles.shotTopRow}>
@@ -356,15 +347,6 @@ const ShotHistoryPanel = React.memo(function ShotHistoryPanel({
               </div>
               <div className={styles.shotMetaRow}>
                 <span className={styles.shotMeta}>{formatShotTime(shot.shot_date)}</span>
-                <button
-                  type="button"
-                  className={styles.shotRowDeleteButton}
-                  onClick={() => onRequestDeleteShot(shot)}
-                  disabled={deletingShotId === shot.shot_id}
-                  aria-label={`Delete shot for ${shot.player_name}`}
-                >
-                  {deletingShotId === shot.shot_id ? 'Deleting…' : 'Delete'}
-                </button>
               </div>
             </li>
           ))}
@@ -388,8 +370,6 @@ const StandingsPage: React.FC = () => {
  const [recentShots, setRecentShots] = useState<ShotFeedItem[]>([]);
  const [isShotHistoryLoading, setIsShotHistoryLoading] = useState<boolean>(true);
  const [shotHistoryError, setShotHistoryError] = useState<string | null>(null);
- const [selectedShot, setSelectedShot] = useState<ShotFeedItem | null>(null);
- const [shotMenuPosition, setShotMenuPosition] = useState<ShotMenuPosition | null>(null);
  const [deletingShotId, setDeletingShotId] = useState<number | null>(null);
  const [shotDeleteStatus, setShotDeleteStatus] = useState<string | null>(null);
  const router = useRouter(); // Router for navigation
@@ -589,22 +569,8 @@ const StandingsPage: React.FC = () => {
     }
   }, [fetchShotHistory]);
 
-  const closeShotContextMenu = useCallback(() => {
-    setSelectedShot(null);
-    setShotMenuPosition(null);
-  }, []);
-
-  const handleShotContextMenu = useCallback((event: React.MouseEvent<HTMLLIElement>, shot: ShotFeedItem) => {
-    event.preventDefault();
-    setSelectedShot(shot);
-    setShotMenuPosition({ x: event.clientX, y: event.clientY });
-    setShotDeleteStatus(null);
-  }, []);
-
   const handleDeleteShot = useCallback(async (shot: ShotFeedItem | null) => {
     if (!shot || deletingShotId !== null) return;
-
-    closeShotContextMenu();
 
     const pointsToRemove = Number(shot.result) || 0;
     const shouldDelete = window.confirm(
@@ -649,26 +615,12 @@ const StandingsPage: React.FC = () => {
     } finally {
       setDeletingShotId(null);
     }
-  }, [closeShotContextMenu, deletingShotId, fetchTeamsAndPlayers]);
+  }, [deletingShotId, fetchTeamsAndPlayers]);
 
-  useEffect(() => {
-    if (!shotMenuPosition) return;
-
-    const handleDocumentPointerDown = () => closeShotContextMenu();
-    const handleEscape = (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        closeShotContextMenu();
-      }
-    };
-
-    document.addEventListener('pointerdown', handleDocumentPointerDown);
-    document.addEventListener('keydown', handleEscape);
-
-    return () => {
-      document.removeEventListener('pointerdown', handleDocumentPointerDown);
-      document.removeEventListener('keydown', handleEscape);
-    };
-  }, [closeShotContextMenu, shotMenuPosition]);
+  const handleShotContextMenu = useCallback((event: React.MouseEvent<HTMLLIElement>, shot: ShotFeedItem) => {
+    event.preventDefault();
+    void handleDeleteShot(shot);
+  }, [handleDeleteShot]);
 
   // useEffect(() => {
   //   // Function to unlock and keep AudioContext alive
@@ -761,14 +713,13 @@ const StandingsPage: React.FC = () => {
 
   const handleShotRealtimeChange = useCallback((payload: { eventType?: string }) => {
     if (payload.eventType === 'DELETE') {
-      closeShotContextMenu();
       setShotDeleteStatus('A shot was deleted. Standings and shot history are up to date.');
     } else if (payload.eventType === 'INSERT') {
       setShotDeleteStatus(null);
     }
 
     queueStandingsRefresh();
-  }, [closeShotContextMenu, queueStandingsRefresh]);
+  }, [queueStandingsRefresh]);
 
   useEffect(() => {
     let userViewChannel: ReturnType<typeof supabase.channel> | null = null;
@@ -965,31 +916,10 @@ const StandingsPage: React.FC = () => {
               error={shotHistoryError}
               deleteStatus={shotDeleteStatus}
               deletingShotId={deletingShotId}
-              selectedShotId={selectedShot?.shot_id ?? null}
               formatShotTime={formatShotTime}
               formatShotResult={formatShotResult}
               onShotContextMenu={handleShotContextMenu}
-              onRequestDeleteShot={handleDeleteShot}
             />
-            {shotMenuPosition && selectedShot && (
-              <div
-                className={styles.shotContextMenu}
-                style={{ top: shotMenuPosition.y, left: shotMenuPosition.x }}
-                role="menu"
-                aria-label={`Shot actions for ${selectedShot.player_name}`}
-                onPointerDown={(event) => event.stopPropagation()}
-              >
-                <button
-                  type="button"
-                  className={styles.shotContextDeleteButton}
-                  role="menuitem"
-                  onClick={() => handleDeleteShot(selectedShot)}
-                  disabled={deletingShotId === selectedShot.shot_id}
-                >
-                  {deletingShotId === selectedShot.shot_id ? 'Deleting…' : 'Delete shot'}
-                </button>
-              </div>
-            )}
           </div>
         </div>
     </main>


### PR DESCRIPTION
### Motivation
- Make the Shot History UI behave like the Shot History elsewhere by invoking the existing delete flow on right-click instead of a no-op context menu and keep the UI minimal. 
- Remove the visible per-row Delete button and the extra “Right-click a shot to delete” instruction to reduce clutter and rely solely on right-click for deletion.

### Description
- Changed the shot row context-menu handler so right-click directly calls the existing `handleDeleteShot` flow instead of showing a custom menu, by updating `onContextMenu` handling in `src/app/Standings/page.tsx`.
- Removed the visible row delete button and the instructional paragraph from `src/app/Standings/page.tsx` so shot rows only show metadata and respond to right-click.
- Removed unused context-menu state (`selectedShot`, `shotMenuPosition`) and associated JSX for the floating menu from `src/app/Standings/page.tsx`.
- Deleted the unused context-menu / delete-button CSS rules from `src/app/Standings/StandingsPage.module.css` and kept the shot row styling (cursor, selected/deleting state).

### Testing
- Ran `npm run lint`, which completed successfully with an unrelated existing warning in `src/app/Admin/page.tsx` remaining. 
- Ran `npm run build`, which completed successfully and produced an optimized build without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa90e87c5c832eb3f2b4b66d789627)