### PR TITLE
Add context menu to delete shots from Standings shot history

### DIFF
--- a/src/app/Standings/StandingsPage.module.css
+++ b/src/app/Standings/StandingsPage.module.css
@@ -84,6 +84,12 @@
 .shotMeta { color:#64748b; font-size:.84rem; }
 .shotMetaRow { margin-top:6px; display:flex; justify-content:space-between; align-items:center; gap:10px; }
 
+.shotContextMenu { position:fixed; z-index:1000; min-width:220px; overflow:hidden; border:1px solid #fecaca; border-radius:12px; background:#fff; box-shadow:0 18px 40px rgba(15,23,42,.18); }
+.shotContextMenuButton { width:100%; border:0; background:#fff; color:#991b1b; padding:10px 12px; text-align:left; cursor:pointer; display:flex; flex-direction:column; gap:3px; font-weight:800; }
+.shotContextMenuButton:hover:not(:disabled), .shotContextMenuButton:focus-visible { background:#fff1f2; outline:none; }
+.shotContextMenuButton:disabled { cursor:not-allowed; opacity:.58; }
+.shotContextMenuButton small { color:#64748b; font-size:.74rem; font-weight:700; }
+
 .team {
   display: flex;
   flex-direction: column;

--- a/src/app/Standings/page.tsx
+++ b/src/app/Standings/page.tsx
@@ -52,6 +52,12 @@ interface ShotFeedItem {
   tier_color: string | null;
 }
 
+interface ShotContextMenuState {
+  shot: ShotFeedItem;
+  x: number;
+  y: number;
+}
+
 
 interface ShotHistoryPanelProps {
   recentShots: ShotFeedItem[];
@@ -372,6 +378,7 @@ const StandingsPage: React.FC = () => {
  const [shotHistoryError, setShotHistoryError] = useState<string | null>(null);
  const [deletingShotId, setDeletingShotId] = useState<number | null>(null);
  const [shotDeleteStatus, setShotDeleteStatus] = useState<string | null>(null);
+ const [shotContextMenu, setShotContextMenu] = useState<ShotContextMenuState | null>(null);
  const router = useRouter(); // Router for navigation
  const hasInitializedRef = useRef(false);
  const isRealtimeSubscribingRef = useRef(false);
@@ -573,10 +580,6 @@ const StandingsPage: React.FC = () => {
     if (!shot || deletingShotId !== null) return;
 
     const pointsToRemove = Number(shot.result) || 0;
-    const shouldDelete = window.confirm(
-      `Delete shot for ${shot.player_name}? This will subtract ${pointsToRemove} points from their score and return one shot.`,
-    );
-    if (!shouldDelete) return;
 
     setDeletingShotId(shot.shot_id);
     setShotDeleteStatus(null);
@@ -607,7 +610,6 @@ const StandingsPage: React.FC = () => {
 
       if (deleteError) throw deleteError;
 
-      setShotDeleteStatus('Shot deleted. Standings and shot history are up to date.');
       await fetchTeamsAndPlayers();
     } catch (error) {
       console.error('Error deleting shot from Standings:', error);
@@ -619,8 +621,20 @@ const StandingsPage: React.FC = () => {
 
   const handleShotContextMenu = useCallback((event: React.MouseEvent<HTMLLIElement>, shot: ShotFeedItem) => {
     event.preventDefault();
-    void handleDeleteShot(shot);
-  }, [handleDeleteShot]);
+    setShotContextMenu({
+      shot,
+      x: event.clientX,
+      y: event.clientY,
+    });
+  }, []);
+
+  const handleContextMenuDeleteShot = useCallback(() => {
+    if (!shotContextMenu) return;
+
+    const shotToDelete = shotContextMenu.shot;
+    setShotContextMenu(null);
+    void handleDeleteShot(shotToDelete);
+  }, [handleDeleteShot, shotContextMenu]);
 
   // useEffect(() => {
   //   // Function to unlock and keep AudioContext alive
@@ -712,9 +726,7 @@ const StandingsPage: React.FC = () => {
   }, [refreshStandings]);
 
   const handleShotRealtimeChange = useCallback((payload: { eventType?: string }) => {
-    if (payload.eventType === 'DELETE') {
-      setShotDeleteStatus('A shot was deleted. Standings and shot history are up to date.');
-    } else if (payload.eventType === 'INSERT') {
+    if (payload.eventType === 'INSERT') {
       setShotDeleteStatus(null);
     }
 
@@ -794,6 +806,27 @@ const StandingsPage: React.FC = () => {
       isRealtimeSubscribingRef.current = false;
     };
   }, [handleShotRealtimeChange, queueStandingsRefresh]);
+
+  useEffect(() => {
+    if (!shotContextMenu) return;
+
+    const closeShotContextMenu = () => setShotContextMenu(null);
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') closeShotContextMenu();
+    };
+
+    window.addEventListener('click', closeShotContextMenu);
+    window.addEventListener('resize', closeShotContextMenu);
+    window.addEventListener('scroll', closeShotContextMenu, true);
+    window.addEventListener('keydown', handleEscape);
+
+    return () => {
+      window.removeEventListener('click', closeShotContextMenu);
+      window.removeEventListener('resize', closeShotContextMenu);
+      window.removeEventListener('scroll', closeShotContextMenu, true);
+      window.removeEventListener('keydown', handleEscape);
+    };
+  }, [shotContextMenu]);
 
  return (
   <div className={styles.userContainer}>
@@ -920,6 +953,27 @@ const StandingsPage: React.FC = () => {
               formatShotResult={formatShotResult}
               onShotContextMenu={handleShotContextMenu}
             />
+            {shotContextMenu && (
+              <div
+                className={styles.shotContextMenu}
+                style={{ top: shotContextMenu.y, left: shotContextMenu.x }}
+                role="menu"
+                aria-label={`Shot actions for ${shotContextMenu.shot.player_name}`}
+                onClick={(event) => event.stopPropagation()}
+                onContextMenu={(event) => event.preventDefault()}
+              >
+                <button
+                  type="button"
+                  className={styles.shotContextMenuButton}
+                  onClick={handleContextMenuDeleteShot}
+                  disabled={deletingShotId !== null}
+                  role="menuitem"
+                >
+                  <span>Delete shot</span>
+                  <small>Subtract {Number(shotContextMenu.shot.result) || 0} point{(Number(shotContextMenu.shot.result) || 0) === 1 ? '' : 's'} and return 1 shot</small>
+                </button>
+              </div>
+            )}
           </div>
         </div>
     </main>


### PR DESCRIPTION
### Motivation
- Improve UX for deleting shots from the shot history by replacing an immediate `window.confirm` prompt with an inline context menu and make deletion accessible from the list without a blocking modal.
- Provide a non-invasive, keyboard/gesture-friendly way to dismiss the menu (click outside, ESC, resize/scroll) and anchor it to the cursor position.
- Simplify realtime status handling for shot changes so insertions clear delete state without showing a separate deletion notice.

### Description
- Added styles for the context menu and buttons in `StandingsPage.module.css` with `.shotContextMenu` and `.shotContextMenuButton`.
- Introduced `ShotContextMenuState`, a `shotContextMenu` state, and handlers `handleShotContextMenu` and `handleContextMenuDeleteShot` to open the menu at `clientX/clientY` and trigger deletion.
- Removed the inline `window.confirm` from `handleDeleteShot` and the success `setShotDeleteStatus` message; deletion is now initiated from the context menu.
- Added a `useEffect` to close the context menu on outside click, `Escape`, `resize`, or `scroll`, and updated the JSX to render a positioned menu with accessible roles and content.
- Adjusted realtime handling in `handleShotRealtimeChange` to clear `shotDeleteStatus` only on `INSERT` events (removed setting a message on `DELETE`).

### Testing
- Ran TypeScript type-check and a local `next build` to ensure the app compiles without type or build errors, both succeeded.
- No unit tests were changed for this PR and existing test suites were not modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa94b9fb0c832e99d09c09a42748fe)